### PR TITLE
Upgraded to spring data solr 2.0.2, which uses version 5.5 of Solr. C…

### DIFF
--- a/annotation-common/src/main/java/uk/ac/ebi/quickgo/annotation/common/AnnotationRepoConfig.java
+++ b/annotation-common/src/main/java/uk/ac/ebi/quickgo/annotation/common/AnnotationRepoConfig.java
@@ -3,9 +3,9 @@ package uk.ac.ebi.quickgo.annotation.common;
 import java.io.File;
 import java.io.IOException;
 import javax.xml.parsers.ParserConfigurationException;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
-import org.apache.solr.client.solrj.impl.HttpSolrServer;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.core.CoreContainer;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,8 +15,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.data.solr.core.SolrTemplate;
 import org.springframework.data.solr.repository.support.SolrRepositoryFactory;
-import org.springframework.data.solr.server.SolrServerFactory;
-import org.springframework.data.solr.server.support.MulticoreSolrServerFactory;
+import org.springframework.data.solr.server.SolrClientFactory;
+import org.springframework.data.solr.server.support.MulticoreSolrClientFactory;
 import org.xml.sax.SAXException;
 
 /**
@@ -36,21 +36,21 @@ public class AnnotationRepoConfig {
     }
 
     @Bean
-    public SolrServer solrServer(SolrServerFactory solrServerFactory) {
-        return solrServerFactory.getSolrServer();
+    public SolrClient solrServer(SolrClientFactory solrClientFactory) {
+        return solrClientFactory.getSolrClient();
     }
 
     @Bean
     @Profile("httpServer")
-    public SolrServerFactory httpSolrServerFactory(@Value("${solr.host}") String solrUrl) {
-        return new MulticoreSolrServerFactory(new HttpSolrServer(solrUrl), SOLR_CORE);
+    public SolrClientFactory httpSolrServerFactory(@Value("${solr.host}") String solrUrl) {
+        return new MulticoreSolrClientFactory(new HttpSolrClient(solrUrl), SOLR_CORE);
     }
 
     @Bean
     @Profile("embeddedServer")
-    public SolrServerFactory embeddedSolrServerFactory(CoreContainer coreContainer)
+    public SolrClientFactory embeddedSolrServerFactory(CoreContainer coreContainer)
             throws IOException, SAXException, ParserConfigurationException {
-        return new MulticoreSolrServerFactory(new EmbeddedSolrServer(coreContainer, SOLR_CORE));
+        return new MulticoreSolrClientFactory(new EmbeddedSolrServer(coreContainer, SOLR_CORE));
     }
 
     @Bean
@@ -62,8 +62,8 @@ public class AnnotationRepoConfig {
     }
 
     @Bean
-    public SolrTemplate annotationTemplate(SolrServerFactory solrServerFactory) {
-        SolrTemplate template = new SolrTemplate(solrServerFactory);
+    public SolrTemplate annotationTemplate(SolrClientFactory solrClientFactory) {
+        SolrTemplate template = new SolrTemplate(solrClientFactory);
         template.setSolrCore(SOLR_CORE);
 
         return template;

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/search/SearchServiceConfig.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/search/SearchServiceConfig.java
@@ -61,7 +61,7 @@ public class SearchServiceConfig {
                 new AnnotationDocConverterImpl());
 
         return new SolrRequestRetrieval<>(
-                annotationTemplate.getSolrServer(),
+                annotationTemplate.getSolrClient(),
                 queryRequestConverter,
                 resultConverter,
                 annotationRetrievalConfig);

--- a/geneproduct-common/src/main/java/uk/ac/ebi/quickgo/geneproduct/common/GeneProductRepoConfig.java
+++ b/geneproduct-common/src/main/java/uk/ac/ebi/quickgo/geneproduct/common/GeneProductRepoConfig.java
@@ -3,9 +3,9 @@ package uk.ac.ebi.quickgo.geneproduct.common;
 import java.io.File;
 import java.io.IOException;
 import javax.xml.parsers.ParserConfigurationException;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
-import org.apache.solr.client.solrj.impl.HttpSolrServer;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.core.CoreContainer;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,8 +15,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.data.solr.core.SolrTemplate;
 import org.springframework.data.solr.repository.support.SolrRepositoryFactory;
-import org.springframework.data.solr.server.SolrServerFactory;
-import org.springframework.data.solr.server.support.MulticoreSolrServerFactory;
+import org.springframework.data.solr.server.SolrClientFactory;
+import org.springframework.data.solr.server.support.MulticoreSolrClientFactory;
 import org.xml.sax.SAXException;
 
 /**
@@ -32,21 +32,21 @@ public class GeneProductRepoConfig {
     }
 
     @Bean
-    public SolrServer solrServer(SolrServerFactory solrServerFactory) {
-        return solrServerFactory.getSolrServer();
+    public SolrClient solrServer(SolrClientFactory solrClientFactory) {
+        return solrClientFactory.getSolrClient();
     }
 
     @Bean
     @Profile("httpServer")
-    public SolrServerFactory httpSolrServerFactory(@Value("${solr.host}") String solrUrl) {
-        return new MulticoreSolrServerFactory(new HttpSolrServer(solrUrl), SOLR_CORE);
+    public SolrClientFactory httpSolrServerFactory(@Value("${solr.host}") String solrUrl) {
+        return new MulticoreSolrClientFactory(new HttpSolrClient(solrUrl), SOLR_CORE);
     }
 
     @Bean
     @Profile("embeddedServer")
-    public SolrServerFactory embeddedSolrServerFactory(CoreContainer coreContainer)
+    public SolrClientFactory embeddedSolrServerFactory(CoreContainer coreContainer)
             throws IOException, SAXException, ParserConfigurationException {
-        return new MulticoreSolrServerFactory(new EmbeddedSolrServer(coreContainer, SOLR_CORE));
+        return new MulticoreSolrClientFactory(new EmbeddedSolrServer(coreContainer, SOLR_CORE));
     }
 
     @Bean
@@ -58,8 +58,8 @@ public class GeneProductRepoConfig {
     }
 
     @Bean
-    public SolrTemplate geneProductTemplate(SolrServerFactory solrServerFactory) {
-        SolrTemplate template = new SolrTemplate(solrServerFactory);
+    public SolrTemplate geneProductTemplate(SolrClientFactory solrClientFactory) {
+        SolrTemplate template = new SolrTemplate(solrClientFactory);
         template.setSolrCore(SOLR_CORE);
 
         return template;

--- a/geneproduct-common/src/test/java/uk/ac/ebi/quickgo/geneproduct/common/GeneProductRepositoryIT.java
+++ b/geneproduct-common/src/test/java/uk/ac/ebi/quickgo/geneproduct/common/GeneProductRepositoryIT.java
@@ -115,8 +115,8 @@ public class GeneProductRepositoryIT {
      */
     private void deleteFromRepositoryByIds(GeneProductDocument... docs) throws SolrServerException, IOException {
         for (GeneProductDocument doc : docs) {
-            geneProductTemplate.getSolrServer().deleteByQuery(GeneProductFields.Searchable.ID + ":" + doc.id);
+            geneProductTemplate.getSolrClient().deleteByQuery(GeneProductFields.Searchable.ID + ":" + doc.id);
         }
-        geneProductTemplate.getSolrServer().commit();
+        geneProductTemplate.getSolrClient().commit();
     }
 }

--- a/geneproduct-rest/src/main/java/uk/ac/ebi/quickgo/geneproduct/service/search/SearchServiceConfig.java
+++ b/geneproduct-rest/src/main/java/uk/ac/ebi/quickgo/geneproduct/service/search/SearchServiceConfig.java
@@ -63,7 +63,7 @@ public class SearchServiceConfig {
         );
 
         return new SolrRequestRetrieval<>(
-                geneProductTemplate.getSolrServer(),
+                geneProductTemplate.getSolrClient(),
                 solrSelectQueryRequestConverter,
                 resultConverter,
                 geneProductRetrievalConfig);

--- a/indexing/pom.xml
+++ b/indexing/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <commons-collections.version>3.2.1</commons-collections.version>
         <quickgo-sources.version>1.0</quickgo-sources.version>
-        <spring-batch-test.version>3.0.5.RELEASE</spring-batch-test.version>
+        <spring-batch-test.version>3.0.7.RELEASE</spring-batch-test.version>
     </properties>
 
     <dependencies>

--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/AnnotationConfig.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/AnnotationConfig.java
@@ -187,6 +187,6 @@ public class AnnotationConfig {
 
     @Bean
     ItemWriter<AnnotationDocument> annotationSolrServerWriter() {
-        return new SolrServerWriter<>(annotationTemplate.getSolrServer());
+        return new SolrServerWriter<>(annotationTemplate.getSolrClient());
     }
 }

--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/common/SolrServerWriter.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/common/SolrServerWriter.java
@@ -3,21 +3,21 @@ package uk.ac.ebi.quickgo.index.common;
 import uk.ac.ebi.quickgo.common.QuickGODocument;
 
 import java.util.List;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.batch.item.ItemWriter;
 
 /**
  * A simple {@link ItemWriter} implementation used for indexing
- * documents directly to a {@link SolrServer} instance.
+ * documents directly to a {@link SolrClient} instance.
  *
  * Created 26/04/16
  * @author Edd
  */
 public class SolrServerWriter<D extends QuickGODocument> implements
                                                          ItemWriter<D> {
-    private final SolrServer server;
+    private final SolrClient server;
 
-    public SolrServerWriter(SolrServer server) {
+    public SolrServerWriter(SolrClient server) {
         this.server = server;
     }
 

--- a/ontology-common/src/main/java/uk/ac/ebi/quickgo/ontology/common/OntologyRepoConfig.java
+++ b/ontology-common/src/main/java/uk/ac/ebi/quickgo/ontology/common/OntologyRepoConfig.java
@@ -3,10 +3,9 @@ package uk.ac.ebi.quickgo.ontology.common;
 import java.io.File;
 import java.io.IOException;
 import javax.xml.parsers.ParserConfigurationException;
-
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
-import org.apache.solr.client.solrj.impl.HttpSolrServer;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.core.CoreContainer;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17,8 +16,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.data.solr.core.SolrTemplate;
 import org.springframework.data.solr.repository.support.SolrRepositoryFactory;
-import org.springframework.data.solr.server.SolrServerFactory;
-import org.springframework.data.solr.server.support.MulticoreSolrServerFactory;
+import org.springframework.data.solr.server.SolrClientFactory;
+import org.springframework.data.solr.server.support.MulticoreSolrClientFactory;
 import org.xml.sax.SAXException;
 
 /**
@@ -36,22 +35,22 @@ public class OntologyRepoConfig {
     }
 
     @Bean
-    public SolrServer solrServer(SolrServerFactory solrServerFactory) {
-        return solrServerFactory.getSolrServer();
+    public SolrClient solrServer(SolrClientFactory solrClientFactory) {
+        return solrClientFactory.getSolrClient();
     }
 
     @Bean
     @Profile("httpServer")
-    public SolrServerFactory httpSolrServerFactory(@Value("${solr.host}") String solrUrl) {
-        return new MulticoreSolrServerFactory(new HttpSolrServer(solrUrl), SOLR_CORE);
+    public SolrClientFactory httpSolrServerFactory(@Value("${solr.host}") String solrUrl) {
+        return new MulticoreSolrClientFactory(new HttpSolrClient(solrUrl), SOLR_CORE);
     }
 
     @Bean
     @Profile("embeddedServer")
-    public SolrServerFactory embeddedSolrServerFactory(CoreContainer coreContainer)
+    public SolrClientFactory embeddedSolrServerFactory(CoreContainer coreContainer)
             throws IOException, SAXException, ParserConfigurationException {
         EmbeddedSolrServer embeddedSolrServer = new EmbeddedSolrServer(coreContainer, SOLR_CORE);
-        return new MulticoreSolrServerFactory(embeddedSolrServer);
+        return new MulticoreSolrClientFactory(embeddedSolrServer);
     }
 
     @Bean
@@ -63,8 +62,8 @@ public class OntologyRepoConfig {
     }
 
     @Bean
-    public SolrTemplate ontologyTemplate(SolrServerFactory solrServerFactory) {
-        SolrTemplate template = new SolrTemplate(solrServerFactory);
+    public SolrTemplate ontologyTemplate(SolrClientFactory solrClientFactory) {
+        SolrTemplate template = new SolrTemplate(solrClientFactory);
         template.setSolrCore(SOLR_CORE);
 
         return template;

--- a/ontology-common/src/test/java/uk/ac/ebi/quickgo/ontology/common/OntologyRepositoryIT.java
+++ b/ontology-common/src/test/java/uk/ac/ebi/quickgo/ontology/common/OntologyRepositoryIT.java
@@ -271,17 +271,17 @@ public class OntologyRepositoryIT {
      */
     @Test
     public void saveDirectlyToSolrServer() throws IOException, SolrServerException {
-        ontologyTemplate.getSolrServer().addBean(OntologyDocMocker.createGODoc("A", "Alice Cooper"));
-        ontologyTemplate.getSolrServer().addBean(OntologyDocMocker.createGODoc("B", "Alice Cooper"));
-        ontologyTemplate.getSolrServer().addBean(OntologyDocMocker.createGODoc("C", "Alice Cooper"));
-        ontologyTemplate.getSolrServer().addBeans(
+        ontologyTemplate.getSolrClient().addBean(OntologyDocMocker.createGODoc("A", "Alice Cooper"));
+        ontologyTemplate.getSolrClient().addBean(OntologyDocMocker.createGODoc("B", "Alice Cooper"));
+        ontologyTemplate.getSolrClient().addBean(OntologyDocMocker.createGODoc("C", "Alice Cooper"));
+        ontologyTemplate.getSolrClient().addBeans(
                 Arrays.asList(
                         OntologyDocMocker.createGODoc("D", "Alice Cooper"),
                         OntologyDocMocker.createGODoc("E", "Alice Cooper")));
 
         assertThat(ontologyRepository.findAll(new PageRequest(0, 10)).getTotalElements(), is(0L));
 
-        ontologyTemplate.getSolrServer().commit();
+        ontologyTemplate.getSolrClient().commit();
 
         assertThat(ontologyRepository.findAll(new PageRequest(0, 10)).getTotalElements(), is(5L));
     }

--- a/ontology-rest/pom.xml
+++ b/ontology-rest/pom.xml
@@ -14,10 +14,6 @@
     <name>Ontology REST service</name>
     <packaging>jar</packaging>
 
-    <properties>
-        <json-path.version>1.2.0</json-path.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/search/SearchServiceConfig.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/search/SearchServiceConfig.java
@@ -1,5 +1,9 @@
 package uk.ac.ebi.quickgo.ontology.service.search;
 
+import uk.ac.ebi.quickgo.ontology.common.OntologyRepoConfig;
+import uk.ac.ebi.quickgo.ontology.model.OBOTerm;
+import uk.ac.ebi.quickgo.ontology.service.converter.ECODocConverter;
+import uk.ac.ebi.quickgo.ontology.service.converter.GODocConverter;
 import uk.ac.ebi.quickgo.rest.search.RequestRetrieval;
 import uk.ac.ebi.quickgo.rest.search.SearchService;
 import uk.ac.ebi.quickgo.rest.search.query.QueryRequestConverter;
@@ -7,10 +11,6 @@ import uk.ac.ebi.quickgo.rest.search.query.SolrQueryConverter;
 import uk.ac.ebi.quickgo.rest.search.solr.SolrRequestRetrieval;
 import uk.ac.ebi.quickgo.rest.search.solr.SolrRetrievalConfig;
 import uk.ac.ebi.quickgo.rest.service.ServiceRetrievalConfig;
-import uk.ac.ebi.quickgo.ontology.common.OntologyRepoConfig;
-import uk.ac.ebi.quickgo.ontology.model.OBOTerm;
-import uk.ac.ebi.quickgo.ontology.service.converter.ECODocConverter;
-import uk.ac.ebi.quickgo.ontology.service.converter.GODocConverter;
 
 import java.util.Arrays;
 import java.util.List;
@@ -60,7 +60,7 @@ public class SearchServiceConfig {
         );
 
         return new SolrRequestRetrieval<>(
-                ontologyTemplate.getSolrServer(),
+                ontologyTemplate.getSolrClient(),
                 solrSelectQueryRequestConverter,
                 resultConverter,
                 ontologyRetrievalConfig);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,20 +29,22 @@
         <jacoco.itReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</jacoco.itReportPath>
 
         <!-- dependency version numbers -->
-        <spring.framework.version>4.1.8.RELEASE</spring.framework.version>
-        <spring.boot.starter>1.2.7.RELEASE</spring.boot.starter>
+        <spring.framework.version>4.2.6.RELEASE</spring.framework.version>
+        <spring.boot.starter>1.3.5.RELEASE</spring.boot.starter>
 
-        <spring-data-solr.version>1.5.0.RELEASE</spring-data-solr.version>
-        <json-path.version>1.2.0</json-path.version>
+        <!--<spring-data-solr.version>1.5.0.RELEASE</spring-data-solr.version>-->
+        <spring-data-solr.version>2.0.2.RELEASE</spring-data-solr.version>
+        <json-path.version>2.0.0</json-path.version>
         <slf4j.version>1.7.12</slf4j.version>
         <logback.version>1.1.3</logback.version>
-        <jackson.version>2.5.2</jackson.version>
+        <!--<jackson.version>2.6.6</jackson.version>-->
+        <jackson.version>2.5.4</jackson.version>
 
         <junit.version>4.12</junit.version>
         <junit-hierarchicalcontextrunner.version>4.12.1</junit-hierarchicalcontextrunner.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito-version>1.9.5</mockito-version>
-        <solr.version>4.10.1</solr.version>
+        <solr.version>5.5.0</solr.version>
 
         <springfox-swagger2.version>2.2.2</springfox-swagger2.version>
 
@@ -73,6 +75,11 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-csv</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
 
@@ -150,6 +157,12 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
+                <version>${spring.framework.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-aop</artifactId>
                 <version>${spring.framework.version}</version>
             </dependency>
 

--- a/quickgo-client/src/main/java/uk/ac/ebi/quickgo/client/service/search/SearchServiceConfig.java
+++ b/quickgo-client/src/main/java/uk/ac/ebi/quickgo/client/service/search/SearchServiceConfig.java
@@ -5,6 +5,7 @@ import uk.ac.ebi.quickgo.client.service.converter.ontology.ECODocConverter;
 import uk.ac.ebi.quickgo.client.service.converter.ontology.GODocConverter;
 import uk.ac.ebi.quickgo.client.service.search.ontology.OntologySearchServiceImpl;
 import uk.ac.ebi.quickgo.client.service.search.ontology.OntologySolrQueryResultConverter;
+import uk.ac.ebi.quickgo.ontology.common.OntologyRepoConfig;
 import uk.ac.ebi.quickgo.rest.search.RequestRetrieval;
 import uk.ac.ebi.quickgo.rest.search.SearchService;
 import uk.ac.ebi.quickgo.rest.search.query.QueryRequestConverter;
@@ -12,7 +13,6 @@ import uk.ac.ebi.quickgo.rest.search.query.SolrQueryConverter;
 import uk.ac.ebi.quickgo.rest.search.solr.SolrRequestRetrieval;
 import uk.ac.ebi.quickgo.rest.search.solr.SolrRetrievalConfig;
 import uk.ac.ebi.quickgo.rest.service.ServiceRetrievalConfig;
-import uk.ac.ebi.quickgo.ontology.common.OntologyRepoConfig;
 
 import java.util.Arrays;
 import java.util.List;
@@ -69,7 +69,7 @@ public class SearchServiceConfig {
 
 
         return new SolrRequestRetrieval<>(
-                ontologyTemplate.getSolrServer(),
+                ontologyTemplate.getSolrClient(),
                 solrSelectQueryRequestConverter,
                 resultConverter,
                 ontologyRetrievalConfig);

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/SolrRequestRetrieval.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/SolrRequestRetrieval.java
@@ -8,8 +8,9 @@ import uk.ac.ebi.quickgo.rest.search.query.QueryRequestConverter;
 import uk.ac.ebi.quickgo.rest.search.results.QueryResult;
 
 import com.google.common.base.Preconditions;
+import java.io.IOException;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrException;
@@ -21,23 +22,23 @@ import org.apache.solr.common.SolrException;
  * @author Edd
  */
 public class SolrRequestRetrieval<T> implements RequestRetrieval<T> {
-    private SolrServer solrServer;
+    private SolrClient solrClient;
     private QueryResultConverter<T, QueryResponse> resultConverter;
     private QueryRequestConverter<SolrQuery> queryRequestConverter;
 
     public SolrRequestRetrieval(
-            SolrServer solrServer,
+            SolrClient solrClient,
             QueryRequestConverter<SolrQuery> queryRequestConverter,
             QueryResultConverter<T, QueryResponse> resultConverter,
             SolrRetrievalConfig serviceProperties) {
-        this.solrServer = solrServer;
+        this.solrClient = solrClient;
         this.resultConverter = resultConverter;
         this.queryRequestConverter = queryRequestConverter;
 
-        checkArguments(solrServer, queryRequestConverter, resultConverter, serviceProperties);
+        checkArguments(solrClient, queryRequestConverter, resultConverter, serviceProperties);
     }
 
-    private void checkArguments(SolrServer solrServer,
+    private void checkArguments(SolrClient solrServer,
             QueryRequestConverter<SolrQuery> queryRequestConverter,
             QueryResultConverter<T, QueryResponse> resultConverter,
             SolrRetrievalConfig serviceProperties) {
@@ -62,9 +63,9 @@ public class SolrRequestRetrieval<T> implements RequestRetrieval<T> {
         SolrQuery query = queryRequestConverter.convert(request);
 
         try {
-            QueryResponse response = solrServer.query(query);
+            QueryResponse response = solrClient.query(query);
             return resultConverter.convert(response, request);
-        } catch (SolrServerException | SolrException  e) {
+        } catch (SolrServerException | SolrException | IOException e) {
             throw new RetrievalException(e);
         }
     }

--- a/solr-cores/src/main/cores/annotation/conf/schema.xml
+++ b/solr-cores/src/main/cores/annotation/conf/schema.xml
@@ -234,23 +234,6 @@
     <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
     <fieldtype name="binary" class="solr.BinaryField"/>
 
-    <!--
-      Note:
-      These should only be used for compatibility with existing indexes (created with lucene or older Solr versions).
-      Use Trie based fields instead. As of Solr 3.5 and 4.x, Trie based fields support sortMissingFirst/Last
-
-      Plain numeric field types that store and index the text
-      value verbatim (and hence don't correctly support range queries, since the
-      lexicographic ordering isn't equal to the numeric ordering)
-
-      NOTE: These field types are deprecated will be removed in Solr 5.0!
-    -->
-    <fieldType name="pint" class="solr.IntField"/>
-    <fieldType name="plong" class="solr.LongField"/>
-    <fieldType name="pfloat" class="solr.FloatField"/>
-    <fieldType name="pdouble" class="solr.DoubleField"/>
-    <fieldType name="pdate" class="solr.DateField" sortMissingLast="true"/>
-
     <!-- The "RandomSortField" is not used to store or search any
          data.  You can declare fields of this type it in your schema
          to generate pseudo-random orderings of your docs for sorting

--- a/solr-cores/src/main/cores/geneproduct/conf/schema.xml
+++ b/solr-cores/src/main/cores/geneproduct/conf/schema.xml
@@ -214,23 +214,6 @@
     <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
     <fieldtype name="binary" class="solr.BinaryField"/>
 
-    <!--
-      Note:
-      These should only be used for compatibility with existing indexes (created with lucene or older Solr versions).
-      Use Trie based fields instead. As of Solr 3.5 and 4.x, Trie based fields support sortMissingFirst/Last
-
-      Plain numeric field types that store and index the text
-      value verbatim (and hence don't correctly support range queries, since the
-      lexicographic ordering isn't equal to the numeric ordering)
-
-      NOTE: These field types are deprecated will be removed in Solr 5.0!
-    -->
-    <fieldType name="pint" class="solr.IntField"/>
-    <fieldType name="plong" class="solr.LongField"/>
-    <fieldType name="pfloat" class="solr.FloatField"/>
-    <fieldType name="pdouble" class="solr.DoubleField"/>
-    <fieldType name="pdate" class="solr.DateField" sortMissingLast="true"/>
-
     <!-- The "RandomSortField" is not used to store or search any
          data.  You can declare fields of this type it in your schema
          to generate pseudo-random orderings of your docs for sorting 

--- a/solr-cores/src/main/cores/miscellaneous/conf/schema.xml
+++ b/solr-cores/src/main/cores/miscellaneous/conf/schema.xml
@@ -265,23 +265,6 @@
     <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
     <fieldtype name="binary" class="solr.BinaryField"/>
 
-    <!--
-      Note:
-      These should only be used for compatibility with existing indexes (created with lucene or older Solr versions).
-      Use Trie based fields instead. As of Solr 3.5 and 4.x, Trie based fields support sortMissingFirst/Last
-
-      Plain numeric field types that store and index the text
-      value verbatim (and hence don't correctly support range queries, since the
-      lexicographic ordering isn't equal to the numeric ordering)
-
-      NOTE: These field types are deprecated will be removed in Solr 5.0!
-    -->
-    <fieldType name="pint" class="solr.IntField"/>
-    <fieldType name="plong" class="solr.LongField"/>
-    <fieldType name="pfloat" class="solr.FloatField"/>
-    <fieldType name="pdouble" class="solr.DoubleField"/>
-    <fieldType name="pdate" class="solr.DateField" sortMissingLast="true"/>
-
     <!-- The "RandomSortField" is not used to store or search any
          data.  You can declare fields of this type it in your schema
          to generate pseudo-random orderings of your docs for sorting

--- a/solr-cores/src/main/cores/ontology/conf/schema.xml
+++ b/solr-cores/src/main/cores/ontology/conf/schema.xml
@@ -213,23 +213,6 @@
     <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
     <fieldtype name="binary" class="solr.BinaryField"/>
 
-    <!--
-      Note:
-      These should only be used for compatibility with existing indexes (created with lucene or older Solr versions).
-      Use Trie based fields instead. As of Solr 3.5 and 4.x, Trie based fields support sortMissingFirst/Last
-
-      Plain numeric field types that store and index the text
-      value verbatim (and hence don't correctly support range queries, since the
-      lexicographic ordering isn't equal to the numeric ordering)
-
-      NOTE: These field types are deprecated will be removed in Solr 5.0!
-    -->
-    <fieldType name="pint" class="solr.IntField"/>
-    <fieldType name="plong" class="solr.LongField"/>
-    <fieldType name="pfloat" class="solr.FloatField"/>
-    <fieldType name="pdouble" class="solr.DoubleField"/>
-    <fieldType name="pdate" class="solr.DateField" sortMissingLast="true"/>
-
     <!-- The "RandomSortField" is not used to store or search any
          data.  You can declare fields of this type it in your schema
          to generate pseudo-random orderings of your docs for sorting


### PR DESCRIPTION
Upgraded to spring data solr 2.0.2, which uses version 5.5 of Solr. Changes required:

* SolrServer usage renamed to new Solr's new SolrClient; for class usages and the interactions with Spring's wrappers
* remove legacy parts of Solr's schema.xmls, which referred to, e.g., 'pint' field types, which are no longer supported in Solr 5.*