### PR TITLE
Goa 1998 filter annotations by gene subset

### DIFF
--- a/annotation-common/src/main/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationFields.java
+++ b/annotation-common/src/main/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationFields.java
@@ -61,6 +61,7 @@ public class AnnotationFields {
         public static final String REFERENCE_SEARCH = storeAndGet(VALUES, AnnotationFields.REFERENCE_SEARCH);
         public static final String GO_ID = storeAndGet(VALUES, AnnotationFields.GO_ID);
         public static final String GENEPRODUCT_ID = storeAndGet(VALUES, AnnotationFields.GENE_PRODUCT_ID);
+        public static final String DB_SUBSET = storeAndGet(VALUES, AnnotationFields.DB_SUBSET);
 
         public static boolean isSearchable(String field) {
             return VALUES.contains(field);

--- a/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocMocker.java
+++ b/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocMocker.java
@@ -24,7 +24,7 @@ public class AnnotationDocMocker {
             "results_in_development_of(UBERON:0006000)");
     public static final String OBJECT_SYMBOL = "moeA5";
     public static final String OBJECT_TYPE = "protein";
-    public static final String SUB_SET = "TrEMBL";
+    public static final String SUB_SET = "KRUK";
     public static final int TAXON_ID = 12345;
 
 

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
@@ -33,11 +33,10 @@ public class AnnotationRequest {
     static final String USAGE_RELATIONSHIPS = "usageRelationships";
     private static final String ASPECT_FIELD = "aspect";
     private static final String[] TARGET_FIELDS = new String[]{ASPECT_FIELD, ASSIGNED_BY, TAXON_ID, GO_EVIDENCE,
-            QUALIFIER, REFERENCE_SEARCH, WITH_FROM_SEARCH, ECO_ID, GENE_PRODUCT_ID, GO_ID, GENE_PRODUCT_TYPE};
+            QUALIFIER, REFERENCE_SEARCH, WITH_FROM_SEARCH, ECO_ID, GENE_PRODUCT_ID, GO_ID, GENE_PRODUCT_TYPE, DB_SUBSET};
 
     private static final int DEFAULT_PAGE_NUMBER = 1;
     private static final String COMMA = ",";
-            QUALIFIER, REFERENCE_SEARCH, WITH_FROM_SEARCH, ECO_ID, GENE_PRODUCT_ID, GO_ID, DB_SUBSET};
 
     @Min(0) @Max(MAX_ENTRIES_PER_PAGE)
     private int limit = DEFAULT_ENTRIES_PER_PAGE;

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
@@ -9,16 +9,7 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
 
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.ASSIGNED_BY;
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.ECO_ID;
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.GENE_PRODUCT_ID;
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.GO_EVIDENCE;
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.REFERENCE_SEARCH;
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.GO_ID;
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.TAXON_ID;
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.WITH_FROM_SEARCH;
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.QUALIFIER;
-
+import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.*;
 
 /**
  * A data structure for the annotation filtering parameters passed in from the client.
@@ -40,7 +31,7 @@ public class AnnotationRequest {
 
     private static final String ASPECT_FIELD = "aspect";
     private static final String[] TARGET_FIELDS = new String[]{ASPECT_FIELD, ASSIGNED_BY, TAXON_ID, GO_EVIDENCE,
-            QUALIFIER, REFERENCE_SEARCH, WITH_FROM_SEARCH, ECO_ID, GENE_PRODUCT_ID, GO_ID};
+            QUALIFIER, REFERENCE_SEARCH, WITH_FROM_SEARCH, ECO_ID, GENE_PRODUCT_ID, GO_ID, DB_SUBSET};
 
     @Min(0) @Max(MAX_ENTRIES_PER_PAGE)
     private int limit = DEFAULT_ENTRIES_PER_PAGE;
@@ -192,6 +183,16 @@ public class AnnotationRequest {
             message = "At least one 'ECO identifier' value is invalid: ${validatedValue}")
     public String getEcoId(){
         return filterMap.get(ECO_ID);
+    }
+
+    public void setGpSubset(String gpSubset){
+        filterMap.put(DB_SUBSET, gpSubset);
+    }
+
+    @Pattern(regexp = "^[A-Za-z-]+(,[A-Za-z-]+)*",
+            message = "At least one 'Gene Product Subset identifier' value is invalid: ${validatedValue}")
+    public String getGpSubset(){
+        return filterMap.get(DB_SUBSET);
     }
 
     public int getLimit() {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -7,7 +7,6 @@ import uk.ac.ebi.quickgo.annotation.common.document.AnnotationDocument;
 import uk.ac.ebi.quickgo.annotation.service.search.SearchServiceConfig;
 import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -32,6 +31,7 @@ import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.*;
 import static uk.ac.ebi.quickgo.annotation.controller.ResponseVerifier.*;
 import static uk.ac.ebi.quickgo.annotation.controller.ResponseVerifier.QUALIFIER;
 import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.DEFAULT_ENTRIES_PER_PAGE;
+import static uk.ac.ebi.quickgo.common.converter.HelpfulConverter.toCSV;
 
 /**
  * RESTful end point for Annotations
@@ -1053,9 +1053,5 @@ public class AnnotationControllerIT {
 
     private int totalPages(int totalEntries, int resultsPerPage) {
         return (int) Math.ceil(totalEntries / resultsPerPage) + 1;
-    }
-
-    private String toCSV(String... values) {
-        return Arrays.stream(values).collect(Collectors.joining(","));
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -953,8 +953,7 @@ public class AnnotationControllerIT {
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(0))
-                .andExpect(fieldsInAllResultsExist(0));
+                .andExpect(totalNumOfResults(0));
     }
 
     //----- Setup data ---------------------//

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -917,7 +917,7 @@ public class AnnotationControllerIT {
         repository.save(docA);
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(GP_SUBSET_PARAM,
-                gimmeCSV(AnnotationDocMocker.SUB_SET, docA.dbSubset)));
+                toCSV(AnnotationDocMocker.SUB_SET, docA.dbSubset)));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -973,7 +973,7 @@ public class AnnotationControllerIT {
         return (int) Math.ceil(totalEntries / resultsPerPage) + 1;
     }
 
-    private String gimmeCSV(String... values) {
+    private String toCSV(String... values) {
         return Arrays.stream(values).collect(Collectors.joining(","));
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
@@ -32,8 +32,10 @@ public class AnnotationRequestValidationIT {
     private static final String[] VALID_GO_EVIDENCE = {"IEA,IBD,IC"};
     private static final String[] INVALID_GO_EVIDENCE = {"9EA,IBDD,I"};
 
-    private static final String[] VALID_GENE_PRODUCT_ID  = {"A0A000","A0A003"};
-    private static final String[] INVALID_GENE_PRODUCT_ID = {"99999","&12345"};
+    private static final String[] VALID_GENE_PRODUCT_ID = {"A0A000", "A0A003"};
+    private static final String[] INVALID_GENE_PRODUCT_ID = {"99999", "&12345"};
+    private static final String[] VALID_GENE_PRODUCT_SUBSET =
+            {"BHF-UCL", "Exosome", "KRUK", "ParkinsonsUK-UCL", "ReferenceGenome"};
 
     @Autowired
     private Validator validator;
@@ -231,7 +233,6 @@ public class AnnotationRequestValidationIT {
                 is("At least one 'Taxonomic identifier' value is invalid: " + taxId));
     }
 
-
     //GENE PRODUCT ID
     @Test
     public void allGeneProductValuesAreValid() {
@@ -262,7 +263,6 @@ public class AnnotationRequestValidationIT {
                         .collect(Collectors.joining(", "))));
     }
 
-
     //GO ID PARAMETER
 
     @Test
@@ -280,7 +280,6 @@ public class AnnotationRequestValidationIT {
                 }
         );
     }
-
 
     @Test
     public void mixedCaseGoIdIsValid() {
@@ -316,7 +315,6 @@ public class AnnotationRequestValidationIT {
         );
     }
 
-
     //ECO PARAMETER
 
     @Test
@@ -351,7 +349,6 @@ public class AnnotationRequestValidationIT {
         );
     }
 
-
     @Test
     public void ecoIdIsInvalid() {
         String[] ecoIds = {"ECO:9", "xxx:0000888", "-"};
@@ -368,6 +365,32 @@ public class AnnotationRequestValidationIT {
                 }
         );
     }
+
+    //GENE PRODUCT SUBSET PARAMETER
+
+    @Test
+    public void setGpSubsetSuccessfully() {
+        String geneProductSubsetValues = gimmeCSV(VALID_GENE_PRODUCT_SUBSET);
+        annotationRequest.setGpSubset(geneProductSubsetValues);
+        assertThat(validator.validate(annotationRequest),hasSize(0));
+    }
+
+    @Test
+    public void invalidGpSubsetValuesResultInError() {
+        String[] subsets = {"9999", "Reference:Genome", "*"};
+
+        Arrays.stream(subsets).forEach(
+                validId -> {
+                    annotationRequest.setGpSubset(validId);
+                    Set<ConstraintViolation<AnnotationRequest>> violations = validator.validate(annotationRequest);
+                    printConstraintViolations(violations);
+                    assertThat(violations.iterator().next().getMessage(),
+                            is("At least one 'Gene Product Subset identifier' value is invalid: " + validId));
+                    assertThat(violations, hasSize(1));
+                }
+        );
+    }
+
 
     //PAGE PARAMETER
     @Test

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
+import static uk.ac.ebi.quickgo.common.converter.HelpfulConverter.*;
 
 /**
  * Tests that the validation added to the {@link AnnotationRequest} class is correct.
@@ -552,7 +553,4 @@ public class AnnotationRequestValidationIT {
         violations.forEach(System.out::println);
     }
 
-    private String toCSV(String... values) {
-        return Arrays.stream(values).collect(Collectors.joining(","));
-    }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
@@ -33,13 +33,10 @@ public class AnnotationRequestValidationIT {
 
     private static final String[] VALID_GO_EVIDENCE = {"IEA,IBD,IC"};
     private static final String[] INVALID_GO_EVIDENCE = {"9EA,IBDD,I"};
-
     private static final String[] VALID_GENE_PRODUCT_ID = {"A0A000", "A0A003"};
     private static final String[] INVALID_GENE_PRODUCT_ID = {"99999", "&12345"};
-    private static final String[] VALID_GENE_PRODUCT_ID = {"A0A000", "A0A003"};
-    private static final String[] INVALID_GENE_PRODUCT_ID = {"99999", "&12345"};
-    private static final String[] VALID_GENE_PRODUCT_SUBSET =
-            {"BHF-UCL", "Exosome", "KRUK", "ParkinsonsUK-UCL", "ReferenceGenome"};
+    private static final String[] VALID_GENE_PRODUCT_SUBSET ={"BHF-UCL", "Exosome", "KRUK", "ParkinsonsUK-UCL",
+            "ReferenceGenome"};
 
     @Autowired
     private Validator validator;
@@ -61,7 +58,7 @@ public class AnnotationRequestValidationIT {
 
     @Test
     public void allAssignedByValuesAreValid() {
-        String assignedByValues = gimmeCSV(VALID_ASSIGNED_BY_PARMS);
+        String assignedByValues = toCSV(VALID_ASSIGNED_BY_PARMS);
         annotationRequest.setAssignedBy(assignedByValues);
         assertThat(validator.validate(annotationRequest), hasSize(0));
     }
@@ -240,21 +237,21 @@ public class AnnotationRequestValidationIT {
     //GENE PRODUCT ID
     @Test
     public void allGeneProductValuesAreValid() {
-        String geneProductIdValues = gimmeCSV(VALID_GENE_PRODUCT_ID);
+        String geneProductIdValues = toCSV(VALID_GENE_PRODUCT_ID);
         annotationRequest.setGpId(geneProductIdValues);
         assertThat(validator.validate(annotationRequest), hasSize(0));
     }
 
     @Test
     public void geneProductIDValidationIsCaseSensitive() {
-        String geneProductIdValues = (gimmeCSV(VALID_GENE_PRODUCT_ID)).toLowerCase();
+        String geneProductIdValues = (toCSV(VALID_GENE_PRODUCT_ID)).toLowerCase();
         annotationRequest.setGpId(geneProductIdValues);
         assertThat(validator.validate(annotationRequest), hasSize(0));
     }
 
     @Test
     public void allGeneProductValuesAreInvalid() {
-        String geneProductIdValues = gimmeCSV(INVALID_GENE_PRODUCT_ID);
+        String geneProductIdValues = toCSV(INVALID_GENE_PRODUCT_ID);
         annotationRequest.setGpId(geneProductIdValues);
         Set<ConstraintViolation<AnnotationRequest>> violations = validator.validate(annotationRequest);
         assertThat(violations, hasSize(1));
@@ -400,7 +397,7 @@ public class AnnotationRequestValidationIT {
 
     @Test
     public void setGpSubsetSuccessfully() {
-        String geneProductSubsetValues = gimmeCSV(VALID_GENE_PRODUCT_SUBSET);
+        String geneProductSubsetValues = toCSV(VALID_GENE_PRODUCT_SUBSET);
         annotationRequest.setGpSubset(geneProductSubsetValues);
         assertThat(validator.validate(annotationRequest),hasSize(0));
     }
@@ -555,7 +552,7 @@ public class AnnotationRequestValidationIT {
         violations.forEach(System.out::println);
     }
 
-    private String gimmeCSV(String... values) {
+    private String toCSV(String... values) {
         return Arrays.stream(values).collect(Collectors.joining(","));
     }
 }

--- a/common/src/main/java/uk/ac/ebi/quickgo/common/converter/HelpfulConverter.java
+++ b/common/src/main/java/uk/ac/ebi/quickgo/common/converter/HelpfulConverter.java
@@ -1,0 +1,25 @@
+package uk.ac.ebi.quickgo.common.converter;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * A useful class for converting stuff.
+ *
+ * @author Tony Wardell
+ * Date: 28/07/2016
+ * Time: 13:51
+ * Created with IntelliJ IDEA.
+ */
+public class HelpfulConverter {
+
+    /**
+     * Turns "AAA", "BBB", "CCC" into "AAA,BBB,CCC".
+     * @param values
+     * @return
+     */
+
+    public static String toCSV(String... values) {
+        return Arrays.stream(values).collect(Collectors.joining(","));
+    }
+}

--- a/common/src/main/java/uk/ac/ebi/quickgo/common/converter/HelpfulConverter.java
+++ b/common/src/main/java/uk/ac/ebi/quickgo/common/converter/HelpfulConverter.java
@@ -1,7 +1,9 @@
 package uk.ac.ebi.quickgo.common.converter;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A useful class for converting stuff.
@@ -20,6 +22,14 @@ public class HelpfulConverter {
      */
 
     public static String toCSV(String... values) {
-        return Arrays.stream(values).collect(Collectors.joining(","));
+        return toCSV(Arrays.stream(values));
+    }
+
+    public static String toCSV(List<String> values) {
+        return toCSV(values.stream());
+    }
+
+    public static String toCSV(Stream<String> stream){
+        return stream.collect(Collectors.joining(","));
     }
 }

--- a/common/src/test/java/uk/ac/ebi/quickgo/common/converter/HelpfulConverterTest.java
+++ b/common/src/test/java/uk/ac/ebi/quickgo/common/converter/HelpfulConverterTest.java
@@ -1,0 +1,19 @@
+package uk.ac.ebi.quickgo.common.converter;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Tony Wardell
+ * Date: 28/07/2016
+ * Time: 13:55
+ * Created with IntelliJ IDEA.
+ */
+public class HelpfulConverterTest {
+
+    @Test
+    public void makeArrayOfStringsIntoSingleCSVString(){
+        assertThat(HelpfulConverter.toCSV(new String[]{"AAA","BBB","CCC"}), is("AAA,BBB,CCC"));
+    }
+}

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
@@ -17,6 +17,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.ac.ebi.quickgo.common.converter.HelpfulConverter.toCSV;
 import static uk.ac.ebi.quickgo.ontology.controller.OBOController.COMPLETE_SUB_RESOURCE;
 import static uk.ac.ebi.quickgo.ontology.controller.OBOController.CONSTRAINTS_SUB_RESOURCE;
 
@@ -36,7 +37,7 @@ public class GOControllerIT extends OBOControllerIT {
     @Test
     public void canRetrieveBlacklistByIds() throws Exception {
         ResultActions response = mockMvc.perform(get(
-                buildTermsURLWithSubResource(asCSV(GO_0000001, GO_0000002), CONSTRAINTS_SUB_RESOURCE)));
+                buildTermsURLWithSubResource(toCSV(GO_0000001, GO_0000002), CONSTRAINTS_SUB_RESOURCE)));
 
         expectBasicFieldsInResults(response, Arrays.asList(GO_0000001, GO_0000002))
                 .andExpect(jsonPath("$.results.*.blacklist", hasSize(2)))

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
@@ -38,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.ac.ebi.quickgo.common.converter.HelpfulConverter.toCSV;
 import static uk.ac.ebi.quickgo.ontology.controller.OBOController.*;
 
 /**
@@ -434,7 +435,7 @@ public abstract class OBOControllerIT {
         String secondBottom = relationships.get(1).child;
 
         ResultActions response = mockMvc.perform(
-                get(buildTermsURLWithSubResource(asCSV(bottom, secondBottom), ANCESTORS_SUB_RESOURCE)));
+                get(buildTermsURLWithSubResource(toCSV(bottom, secondBottom), ANCESTORS_SUB_RESOURCE)));
 
         response.andDo(print())
                 .andExpect(jsonPath("$.numberOfHits").value(2))
@@ -500,7 +501,7 @@ public abstract class OBOControllerIT {
         createAndSaveDocs(relCount + 1);
 
         ResultActions response = mockMvc.perform(
-                get(buildTermsURLWithSubResource(asCSV(top, secondTop), DESCENDANTS_SUB_RESOURCE)));
+                get(buildTermsURLWithSubResource(toCSV(top, secondTop), DESCENDANTS_SUB_RESOURCE)));
 
         response.andDo(print())
                 .andExpect(jsonPath("$.numberOfHits").value(2))
@@ -564,7 +565,7 @@ public abstract class OBOControllerIT {
         String highest = relationships.get(relationships.size() - 1).parent;
 
         ResultActions response = mockMvc.perform(
-                get(buildPathsURL(asCSV(bottom, secondBottom), highest)));
+                get(buildPathsURL(toCSV(bottom, secondBottom), highest)));
 
         response.andDo(print())
                 .andExpect(jsonPath("$.numberOfHits").value(2))
@@ -579,7 +580,7 @@ public abstract class OBOControllerIT {
         String secondTop = relationships.get(relationships.size() - 2).parent;
 
         ResultActions response = mockMvc.perform(
-                get(buildPathsURL(bottom, asCSV(top, secondTop))));
+                get(buildPathsURL(bottom, toCSV(top, secondTop))));
 
         response.andDo(print())
                 .andExpect(jsonPath("$.numberOfHits").value(2))
@@ -756,10 +757,6 @@ public abstract class OBOControllerIT {
         }
 
         return result;
-    }
-
-    static String asCSV(String... values) {
-        return Arrays.stream(values).collect(Collectors.joining(","));
     }
 
     private void setupSimpleRelationshipChain() {

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
@@ -93,8 +93,8 @@ public abstract class OBOControllerIT {
         assertThat(basicDocs.size(), is(greaterThan(1)));
 
         validId = basicDocs.get(0).id;
-        validIdsCSV = basicDocs.stream().map(doc -> doc.id).collect(Collectors.joining(","));
-        validIdList = Arrays.asList(validIdsCSV.split(COMMA));
+        validIdList =  basicDocs.stream().map(doc -> doc.id).collect(Collectors.toList());
+        validIdsCSV = toCSV(validIdList);
 
         ontologyRepository.deleteAll();
         ontologyRepository.save(basicDocs);

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/validation/OBOControllerValidationHelperImplTest.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/validation/OBOControllerValidationHelperImplTest.java
@@ -5,7 +5,6 @@ import uk.ac.ebi.quickgo.ontology.model.OntologyRelationType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -14,6 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static uk.ac.ebi.quickgo.common.converter.HelpfulConverter.toCSV;
 import static uk.ac.ebi.quickgo.ontology.model.OntologyRelationType.DEFAULT_TRAVERSAL_TYPES;
 
 /**
@@ -67,8 +67,10 @@ public class OBOControllerValidationHelperImplTest {
         OntologyRelationType validRelation0 = OntologyRelationType.DEFAULT_TRAVERSAL_TYPES.get(0);
         OntologyRelationType validRelation1 = OntologyRelationType.DEFAULT_TRAVERSAL_TYPES.get(1);
 
-        List<OntologyRelationType> validRelations = validator.validateRelationTypes(
-                relationsToCSV(validRelation0, validRelation1));
+//        List<OntologyRelationType> validRelations = validator.validateRelationTypes(
+//                relationsToCSV(validRelation0, validRelation1));
+        List<OntologyRelationType> validRelations = validator.validateRelationTypes(toCSV
+                        (validRelation0.getLongName(), validRelation1.getLongName()));
 
         assertThat(validRelations, containsInAnyOrder(validRelation0, validRelation1));
     }
@@ -81,10 +83,8 @@ public class OBOControllerValidationHelperImplTest {
     @Test(expected = IllegalArgumentException.class)
     public void checkValidationWorksFor2InvalidRelations() {
         validator.validateRelationTypes(
-                relationsToCSV(invalidRelationships.get(0), invalidRelationships.get(1)));
+                toCSV(invalidRelationships.get(0).getLongName(), invalidRelationships.get(1)
+                        .getLongName()));
     }
 
-    private String relationsToCSV(OntologyRelationType... relations) {
-        return asList(relations).stream().map(OntologyRelationType::getLongName).collect(Collectors.joining(","));
-    }
 }


### PR DESCRIPTION
As a QuickGO user
I would like to be able to filter annotations using a specific group to which a set of gene products belong to
So that I can see annotations that are associated to that/those particular gene product(s)
Acceptance criteria:
If the gene product subset does not match any of the ids on the annotation list, then the result should be empty
If the subset matches at least one of the subsets of a gene product in the list of annotations, then the result should only show the affected annotations
The user can input more than one subset, when this is the case then the ids should be ORed.
This filter criteria can be used in conjunction with other non-related filter criteria
The filter should be case-insensitive