### PR TITLE
Goa 2245 make gene product filter case insensitive

### DIFF
--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
@@ -246,11 +246,7 @@ public class AnnotationRequestValidationIT {
     public void geneProductIDValidationIsCaseSensitive() {
         String geneProductIdValues = (gimmeCSV(VALID_GENE_PRODUCT_ID)).toLowerCase();
         annotationRequest.setGpId(geneProductIdValues);
-        Set<ConstraintViolation<AnnotationRequest>> violations = validator.validate(annotationRequest);
-        assertThat(violations, hasSize(1));
-        assertThat(violations.iterator().next().getMessage(),
-                is("At least one 'Gene Product ID' value is invalid: " +
-                        (Arrays.stream(VALID_GENE_PRODUCT_ID).collect(Collectors.joining(", "))).toLowerCase()));
+        assertThat(validator.validate(annotationRequest), hasSize(0));
     }
 
     @Test

--- a/common/src/main/java/uk/ac/ebi/quickgo/common/validator/DbXRefEntity.java
+++ b/common/src/main/java/uk/ac/ebi/quickgo/common/validator/DbXRefEntity.java
@@ -30,7 +30,7 @@ public class DbXRefEntity {
                 "The regex for the validation of ids from " + database + " is null and therefore invalid");
         this.database = database;
         this.entityType = entityType;
-        this.idValidationPattern = Pattern.compile(idValidationPattern);
+        this.idValidationPattern = Pattern.compile(idValidationPattern, Pattern.CASE_INSENSITIVE);
         this.entityTypeName = entityTypeName;
         this.databaseURL = databaseURL;
     }


### PR DESCRIPTION
 All searching / filtering should be case-insensitive; to not do this would be user-hostile. Use the CASE_INSENSITIVE flag when constructing the Pattern object.