### PR TITLE
GOA-2237_Add_credits_to_ontology_model

### DIFF
--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/ontology/converter/GenericTermToODocConverter.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/ontology/converter/GenericTermToODocConverter.java
@@ -45,11 +45,27 @@ public class GenericTermToODocConverter implements Function<Optional<? extends G
 
             doc.replaces = extractReplaces(term);
             doc.replacements = extractReplacements(term);
+            doc.credits = extractCredits(term);
 
             return Optional.of(doc);
         } else {
             return Optional.empty();
         }
+    }
+
+    private List<String> extractCredits(GenericTerm term) {
+        List<String> extractedCredits = null;
+
+        if (!isEmpty(term.getCredits())) {
+            extractedCredits = term.getCredits().stream()
+                    .map(credit -> FlatFieldBuilder.newFlatField()
+                            .addField(FlatFieldLeaf.newFlatFieldLeaf(credit.getCode()))
+                            .addField(FlatFieldLeaf.newFlatFieldLeaf(credit.getUrl()))
+                            .buildString())
+                    .collect(Collectors.toList());
+        }
+
+        return extractedCredits;
     }
 
     protected List<String> extractDefinitionXrefs(GenericTerm term) {

--- a/ontology-common/src/main/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyDocument.java
+++ b/ontology-common/src/main/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyDocument.java
@@ -82,6 +82,9 @@ public class OntologyDocument implements QuickGODocument {
     @Field(OntologyFields.GO_DISCUSSIONS)
     public List<String> goDiscussions;
 
+    @Field(OntologyFields.CREDITS)
+    public List<String> credits;
+
     @Override
     public String getUniqueName() {
         return this.id;
@@ -164,6 +167,10 @@ public class OntologyDocument implements QuickGODocument {
             return false;
         }
 
+        if (credits != null ? !credits.equals(that.credits) : that.credits != null) {
+            return false;
+        }
+
         return !(xRelations != null ? !xRelations.equals(that.xRelations) : that.xRelations != null);
 
     }
@@ -191,6 +198,7 @@ public class OntologyDocument implements QuickGODocument {
         result = 31 * result + (annotationGuidelines != null ? annotationGuidelines.hashCode() : 0);
         result = 31 * result + (xRelations != null ? xRelations.hashCode() : 0);
         result = 31 * result + (goDiscussions != null ? goDiscussions.hashCode() : 0);
+        result = 31 * result + (credits != null ? credits.hashCode() : 0);
         return result;
     }
 
@@ -218,6 +226,7 @@ public class OntologyDocument implements QuickGODocument {
                 ", annotationGuidelines=" + annotationGuidelines +
                 ", xRelations=" + xRelations +
                 ", goDiscussions=" + goDiscussions +
+                ", credits=" + credits +
                 '}';
     }
 }

--- a/ontology-common/src/main/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyFields.java
+++ b/ontology-common/src/main/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyFields.java
@@ -41,6 +41,7 @@ public class OntologyFields {
     public final static String EXACT_NAME = "exact_name";
     public final static String EXACT_SYNONYM = "exact_synonym";
     public final static String GO_DISCUSSIONS = "goDiscussions";
+    public final static String CREDITS = "credits";
 
     /**
      * Ontology fields that are stored, and can therefore be retrieved.
@@ -71,6 +72,7 @@ public class OntologyFields {
         public static final String DEFINITION_XREF = storeAndGet(VALUES, OntologyFields.DEFINITION_XREFS);
         public static final String ANCESTOR = storeAndGet(VALUES, OntologyFields.ANCESTOR);
         public static final String GO_DISCUSSIONS = storeAndGet(VALUES, OntologyFields.GO_DISCUSSIONS);
+        public static final String CREDITS = storeAndGet(VALUES, OntologyFields.CREDITS);
 
         public static boolean isRetrievable(String field) {
             return VALUES.contains(field);

--- a/ontology-common/src/test/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyDocMocker.java
+++ b/ontology-common/src/test/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyDocMocker.java
@@ -63,13 +63,6 @@ public final class OntologyDocMocker {
                 .addField(newFlatFieldLeaf("http://wiki.geneontology.org/index.php/Signaling"))
                 .buildString());
 
-        od.credits = new ArrayList<>();
-        od.credits.add(newFlatFieldFromDepth(FLAT_FIELD_DEPTH)
-                .addField(newFlatFieldLeaf("BHF"))
-                .addField(newFlatFieldLeaf("http://www.ucl.ac.uk/cardiovasculargeneontology/"))
-                .buildString());
-
-
         return od;
     }
 
@@ -219,6 +212,12 @@ public final class OntologyDocMocker {
         od.replacements.add(createFlatRelation("GO:0000002", "replaced_by"));
         od.replacements.add(createFlatRelation("GO:0000003", "consider"));
         od.replacements.add(createFlatRelation("GO:0000004", "consider"));
+
+        od.credits = new ArrayList<>();
+        od.credits.add(newFlatFieldFromDepth(FLAT_FIELD_DEPTH)
+                .addField(newFlatFieldLeaf("BHF"))
+                .addField(newFlatFieldLeaf("http://www.ucl.ac.uk/cardiovasculargeneontology/"))
+                .buildString());
 
         return od;
     }

--- a/ontology-common/src/test/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyDocMocker.java
+++ b/ontology-common/src/test/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyDocMocker.java
@@ -63,6 +63,13 @@ public final class OntologyDocMocker {
                 .addField(newFlatFieldLeaf("http://wiki.geneontology.org/index.php/Signaling"))
                 .buildString());
 
+        od.credits = new ArrayList<>();
+        od.credits.add(newFlatFieldFromDepth(FLAT_FIELD_DEPTH)
+                .addField(newFlatFieldLeaf("BHF"))
+                .addField(newFlatFieldLeaf("http://www.ucl.ac.uk/cardiovasculargeneontology/"))
+                .buildString());
+
+
         return od;
     }
 

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/GOTerm.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/GOTerm.java
@@ -21,7 +21,7 @@ public class GOTerm extends OBOTerm {
     public Usage usage;
 
     public List<BlacklistItem> blacklist;
-    public List<GoDiscussion> goDiscussions;
+    public List<GODiscussion> goDiscussions;
 
     public enum Usage {
         UNRESTRICTED("Unrestricted", "U"),
@@ -73,7 +73,7 @@ public class GOTerm extends OBOTerm {
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public static class GoDiscussion implements FieldType {
+    public static class GODiscussion implements FieldType {
         public String title;
         public String url;
     }

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/OBOTerm.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/OBOTerm.java
@@ -59,7 +59,10 @@ public class OBOTerm {
     public List<XORelation> xRelations;
 
     public List<AnnotationGuideLine> annotationGuidelines;
+
     public List<TaxonConstraint> taxonConstraints;
+
+    public List<Credit> credits;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public static class Synonym implements FieldType {
@@ -122,5 +125,11 @@ public class OBOTerm {
     public static class Replace implements FieldType {
         public String id;
         public String type;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class Credit implements FieldType {
+        public String code;
+        public String url;
     }
 }

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/AbstractODocConverter.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/AbstractODocConverter.java
@@ -31,6 +31,7 @@ abstract class AbstractODocConverter<T extends OBOTerm> implements OntologyDocCo
             new XRefsFieldConverter();
     private final static DefinitionConverter DEFINITION_CONVERTER = new DefinitionConverter();
     private final static ReplaceConverter REPLACES_CONVERTER = new ReplaceConverter();
+    private final static CreditsFieldConverter CREDITS_FIELD_CONVERTER = new CreditsFieldConverter();
 
     public abstract T convert(OntologyDocument ontologyDocument);
 
@@ -51,5 +52,6 @@ abstract class AbstractODocConverter<T extends OBOTerm> implements OntologyDocCo
         term.annotationGuidelines = AG_FIELD_CONVERTER.convertFieldList(ontologyDocument.annotationGuidelines);
         term.replaces = REPLACES_CONVERTER.convertFieldList(ontologyDocument.replaces);
         term.replacements = REPLACES_CONVERTER.convertFieldList(ontologyDocument.replacements);
+        term.credits = CREDITS_FIELD_CONVERTER.convertFieldList(ontologyDocument.credits);
     }
 }

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/CreditsFieldConverter.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/CreditsFieldConverter.java
@@ -1,0 +1,47 @@
+package uk.ac.ebi.quickgo.ontology.service.converter;
+
+import uk.ac.ebi.quickgo.common.converter.FieldConverter;
+import uk.ac.ebi.quickgo.common.converter.FlatField;
+import uk.ac.ebi.quickgo.ontology.model.OBOTerm;
+
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static uk.ac.ebi.quickgo.common.converter.FlatFieldBuilder.newFlatField;
+
+/**
+ * Defines the conversion of a {@link String} representing credit to an external funding agency, to a
+ * corresponding {@link uk.ac.ebi.quickgo.ontology.model.OBOTerm.Credit} instance.
+ * <p>
+ * A {@link String} representation is of the form:
+ * <ul>
+ *     <li>code|url</li>
+ * </ul>
+ * <p>
+ * @author Ricardo Antunes
+ */
+class CreditsFieldConverter implements FieldConverter<OBOTerm.Credit> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreditsFieldConverter.class);
+    private static final int FIELD_COUNT = 2;
+
+    @Override public Optional<OBOTerm.Credit> apply(String fieldStr) {
+        List<FlatField> fields = newFlatField().parse(fieldStr).getFields();
+
+        Optional<OBOTerm.Credit> creditOpt;
+
+        if (fields.size() == FIELD_COUNT) {
+            OBOTerm.Credit credit = new OBOTerm.Credit();
+            credit.code = cleanFieldValue(fields.get(0).buildString());
+            credit.url = cleanFieldValue(fields.get(1).buildString());
+
+            creditOpt = Optional.of(credit);
+        } else {
+            LOGGER.warn("Could not parse flattened credit: {}", fieldStr);
+            creditOpt = Optional.empty();
+        }
+
+        return creditOpt;
+    }
+}

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/GODiscussionConverter.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/GODiscussionConverter.java
@@ -13,7 +13,7 @@ import static uk.ac.ebi.quickgo.common.converter.FlatFieldBuilder.newFlatField;
 
 /**
  * Defines the conversion of a {@link String} representing GO discussion information, to a
- * corresponding {@link uk.ac.ebi.quickgo.ontology.model.GOTerm.GoDiscussion} instance.
+ * corresponding {@link GOTerm.GODiscussion} instance.
  * <p>
  * A {@link String} representation is of the form:
  * <ul>
@@ -22,17 +22,17 @@ import static uk.ac.ebi.quickgo.common.converter.FlatFieldBuilder.newFlatField;
  * <p>
  * @author Ricardo Antunes
  */
-class GoDiscussionConverter implements FieldConverter<GOTerm.GoDiscussion> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(GoDiscussionConverter.class);
+class GODiscussionConverter implements FieldConverter<GOTerm.GODiscussion> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GODiscussionConverter.class);
     private static final int FIELD_COUNT = 2;
 
-    @Override public Optional<GOTerm.GoDiscussion> apply(String fieldStr) {
+    @Override public Optional<GOTerm.GODiscussion> apply(String fieldStr) {
         List<FlatField> fields = newFlatField().parse(fieldStr).getFields();
 
-        Optional<GOTerm.GoDiscussion> goDiscussionOpt;
+        Optional<GOTerm.GODiscussion> goDiscussionOpt;
 
         if (fields.size() == FIELD_COUNT) {
-            GOTerm.GoDiscussion discussion = new GOTerm.GoDiscussion();
+            GOTerm.GODiscussion discussion = new GOTerm.GODiscussion();
             discussion.title = cleanFieldValue(fields.get(0).buildString());
             discussion.url = cleanFieldValue(fields.get(1).buildString());
 

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/GODocConverter.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/GODocConverter.java
@@ -15,8 +15,8 @@ public class GODocConverter extends AbstractODocConverter<GOTerm> {
     private final static BlackListFieldConverter BLACKLIST_FIELD_CONVERTER =
             new BlackListFieldConverter();
 
-    private final static GoDiscussionConverter GO_DISCUSSION_CONVERTER =
-            new GoDiscussionConverter();
+    private final static GODiscussionConverter GO_DISCUSSION_CONVERTER =
+            new GODiscussionConverter();
 
     @Override public GOTerm convert(OntologyDocument ontologyDocument) {
         GOTerm goTerm = new GOTerm();

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/GoDiscussionConverter.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/GoDiscussionConverter.java
@@ -22,7 +22,7 @@ import static uk.ac.ebi.quickgo.common.converter.FlatFieldBuilder.newFlatField;
  * <p>
  * @author Ricardo Antunes
  */
-public class GoDiscussionConverter implements FieldConverter<GOTerm.GoDiscussion> {
+class GoDiscussionConverter implements FieldConverter<GOTerm.GoDiscussion> {
     private static final Logger LOGGER = LoggerFactory.getLogger(GoDiscussionConverter.class);
     private static final int FIELD_COUNT = 2;
 

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
@@ -720,7 +720,8 @@ public abstract class OBOControllerIT {
                 .andExpect(jsonPath(path + "taxonConstraints").exists())
                 .andExpect(jsonPath(path + "subsets").exists())
                 .andExpect(jsonPath(path + "replacements").exists())
-                .andExpect(jsonPath(path + "replaces").exists());
+                .andExpect(jsonPath(path + "replaces").exists())
+                .andExpect(jsonPath(path + "credits").exists());
     }
 
     protected ResultActions expectInvalidIdError(ResultActions result, String id) throws Exception {

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/service/converter/AbstractODocConverterTest.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/service/converter/AbstractODocConverterTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -43,12 +42,12 @@ public class AbstractODocConverterTest {
      */
     @Test
     public void convertsIdWithoutError() {
-        assertThat(oboTermFromValidGODoc.id, is(equalTo("id1")));
+        assertThat(oboTermFromValidGODoc.id, is("id1"));
     }
 
     @Test
     public void convertsNameWithoutError() {
-        assertThat(oboTermFromValidGODoc.name, is(equalTo("name1")));
+        assertThat(oboTermFromValidGODoc.name, is("name1"));
     }
 
     @Test
@@ -88,7 +87,12 @@ public class AbstractODocConverterTest {
 
     @Test
     public void convertsSynonymsWithoutError() {
-        assertThat(oboTermFromValidGODoc.synonyms.size(), is(equalTo(2)));
+        assertThat(oboTermFromValidGODoc.synonyms.size(), is(validGODoc.synonyms.size()));
+    }
+
+    @Test
+    public void convertsCreditsWithoutError() {
+        assertThat(oboTermFromValidGODoc.credits.size(), is(validGODoc.credits.size()));
     }
 
     /**

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/service/converter/CreditsFieldConverterTest.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/service/converter/CreditsFieldConverterTest.java
@@ -1,0 +1,57 @@
+package uk.ac.ebi.quickgo.ontology.service.converter;
+
+import uk.ac.ebi.quickgo.common.converter.FlatFieldBuilder;
+import uk.ac.ebi.quickgo.common.converter.FlatFieldLeaf;
+import uk.ac.ebi.quickgo.ontology.model.OBOTerm;
+
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests the behaviour of the {@link CreditsFieldConverter} class.
+ */
+public class CreditsFieldConverterTest {
+    private CreditsFieldConverter converter;
+
+    @Before
+    public void setUp() throws Exception {
+        converter = new CreditsFieldConverter();
+    }
+
+    @Test
+    public void convertsValidTextBasedCredit() throws Exception {
+        String code = "BHF";
+        String url = "http://www.ucl.ac.uk/cardiovasculargeneontology/";
+
+        String creditText = createCreditText(code, url);
+
+        Optional<OBOTerm.Credit> expectedCreditOpt = converter.apply(creditText);
+
+        assertThat(expectedCreditOpt.isPresent(), is(true));
+
+        OBOTerm.Credit expectedCredit = expectedCreditOpt.get();
+
+        assertThat(expectedCredit.code, is(code));
+        assertThat(expectedCredit.url, is(url));
+    }
+
+    @Test
+    public void returnsEmptyOptionalWhenTextBasedCreditHasWrongNumberOfFields() throws Exception {
+        String wrongTextFormatCredit = "Wrong format";
+
+        Optional<OBOTerm.Credit> expectedCreditOpt = converter.apply(wrongTextFormatCredit);
+
+        assertThat(expectedCreditOpt.isPresent(), is(false));
+    }
+
+    private String createCreditText(String code, String url) {
+        return FlatFieldBuilder.newFlatField()
+                .addField(FlatFieldLeaf.newFlatFieldLeaf(code))
+                .addField(FlatFieldLeaf.newFlatFieldLeaf(url))
+                .buildString();
+    }
+}

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/service/converter/GODiscussionConverterTest.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/service/converter/GODiscussionConverterTest.java
@@ -12,14 +12,14 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * Tests the behaviour of the {@link GoDiscussionConverter} class.
+ * Tests the behaviour of the {@link GODiscussionConverter} class.
  */
-public class GoDiscussionConverterTest {
-    private GoDiscussionConverter converter;
+public class GODiscussionConverterTest {
+    private GODiscussionConverter converter;
 
     @Before
     public void setUp() throws Exception {
-        converter = new GoDiscussionConverter();
+        converter = new GODiscussionConverter();
     }
 
     @Test
@@ -29,21 +29,21 @@ public class GoDiscussionConverterTest {
 
         String goDiscussionText = createGoDiscussionText(title, url);
 
-        Optional<GOTerm.GoDiscussion> expectedGoDiscussionOpt = converter.apply(goDiscussionText);
+        Optional<GOTerm.GODiscussion> expectedGoDiscussionOpt = converter.apply(goDiscussionText);
 
         assertThat(expectedGoDiscussionOpt.isPresent(), is(true));
 
-        GOTerm.GoDiscussion expectedGoDiscussion = expectedGoDiscussionOpt.get();
+        GOTerm.GODiscussion expectedGODiscussion = expectedGoDiscussionOpt.get();
 
-        assertThat(expectedGoDiscussion.title, is(title));
-        assertThat(expectedGoDiscussion.url, is(url));
+        assertThat(expectedGODiscussion.title, is(title));
+        assertThat(expectedGODiscussion.url, is(url));
     }
 
     @Test
     public void returnsEmptyOptionalWhenTextBasedGoDiscussionHasWrongNumberOfFields() throws Exception {
         String wrongTextFormatGoDiscussion = "Wrong format";
 
-        Optional<GOTerm.GoDiscussion> expectedGoDiscussionOpt = converter.apply(wrongTextFormatGoDiscussion);
+        Optional<GOTerm.GODiscussion> expectedGoDiscussionOpt = converter.apply(wrongTextFormatGoDiscussion);
 
         assertThat(expectedGoDiscussionOpt.isPresent(), is(false));
     }

--- a/solr-cores/src/main/cores/ontology/conf/schema.xml
+++ b/solr-cores/src/main/cores/ontology/conf/schema.xml
@@ -46,6 +46,7 @@
     <field name="taxonConstraint" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="blacklist" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="goDiscussions" type="string" indexed="false" stored="true" multiValued="true"/>
+    <field name="credits" type="string" indexed="false" stored="true" multiValued="true"/>
 
     <!-- autocomplete search fields -->
     <field name="edge_name" type="text_edge" indexed="true" stored="true" multiValued="false"/>


### PR DESCRIPTION
Contains code to add credits (acknowledgments to projects that help fund the creation of the ontology term).