### PR TITLE
Goa 2241 regex for rna not working

### DIFF
--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -70,9 +70,6 @@ public class AnnotationControllerIT {
     private static final String ECO_ID2 = "ECO:0000323";
     private static final String NOTEXISTS_ECO_ID3 = "ECO:0000888";
 
-    //Configuration
-    private static final int NUMBER_OF_GENERIC_DOCS = 3;
-
     private MockMvc mockMvc;
     private List<AnnotationDocument> genericDocs;
     @Autowired
@@ -88,8 +85,8 @@ public class AnnotationControllerIT {
         mockMvc = MockMvcBuilders.
                 webAppContextSetup(webApplicationContext)
                 .build();
-
-        genericDocs = createGenericDocs(NUMBER_OF_GENERIC_DOCS);
+        final int numberOfGenericDocs = 3;
+        genericDocs = createGenericDocs(numberOfGenericDocs);
         repository.save(genericDocs);
     }
 
@@ -267,11 +264,10 @@ public class AnnotationControllerIT {
         String goEvidenceCode = "IEA";
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GO_EVIDENCE_PARAM, goEvidenceCode));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3))
                 .andExpect(atLeastOneResultHasItem(GO_EVIDENCE_FIELD, goEvidenceCode));
     }
 
@@ -283,8 +279,8 @@ public class AnnotationControllerIT {
 
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3))
                 .andExpect(atLeastOneResultHasItem(GO_EVIDENCE_FIELD, goEvidenceCode.toUpperCase()));
     }
 
@@ -314,14 +310,13 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GO_EVIDENCE_PARAM, "IEA,BSS,AWE,PEG"));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 2))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 2))
+                .andExpect(totalNumOfResults(5))
+                .andExpect(fieldsInAllResultsExist(5))
                 .andExpect(itemExistsExpectedTimes(GO_EVIDENCE_FIELD, goEvidenceCode1, 1))
                 .andExpect(itemExistsExpectedTimes(GO_EVIDENCE_FIELD, goEvidenceCode2, 1))
-                .andExpect(itemExistsExpectedTimes(GO_EVIDENCE_FIELD, goEvidenceCode, NUMBER_OF_GENERIC_DOCS));
+                .andExpect(itemExistsExpectedTimes(GO_EVIDENCE_FIELD, goEvidenceCode, 3));
     }
 
     @Test
@@ -341,12 +336,11 @@ public class AnnotationControllerIT {
         String qualifier = "enables";
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(QUALIFIER_PARAM, qualifier));
-
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3))
                 .andExpect(valueOccurInField(QUALIFIER, qualifier));
 
     }
@@ -396,11 +390,10 @@ public class AnnotationControllerIT {
         sj.add(uniprotGp).add(intactGp).add(rnaGp);
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GP_PARAM, sj.toString()));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3))
                 .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, uniprotGp, 1))
                 .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, intactGp, 1))
                 .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, rnaGp, 1));
@@ -418,11 +411,10 @@ public class AnnotationControllerIT {
         sj.add(uniprotGp).add(intactGp).add(rnaGp);
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GP_PARAM, sj.toString()));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3))
                 .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, uniprotGp, 1))
                 .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, intactGp, 1))
                 .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, rnaGp, 1));
@@ -492,26 +484,24 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GO_ID_PARAM, AnnotationDocMocker.GO_ID));
-
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(itemExistsExpectedTimes(GO_ID, AnnotationDocMocker.GO_ID, NUMBER_OF_GENERIC_DOCS));
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3))
+                .andExpect(itemExistsExpectedTimes(GO_ID, AnnotationDocMocker.GO_ID, 3));
     }
 
     @Test
     public void successfullyLookupAnnotationsByGoIdCaseInsensitive() throws Exception {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GO_ID_PARAM, AnnotationDocMocker.GO_ID.toLowerCase()));
-
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(itemExistsExpectedTimes(GO_ID, AnnotationDocMocker.GO_ID, NUMBER_OF_GENERIC_DOCS));
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3))
+                .andExpect(itemExistsExpectedTimes(GO_ID, AnnotationDocMocker.GO_ID, 3));
     }
 
     @Test
@@ -541,11 +531,10 @@ public class AnnotationControllerIT {
     public void filterAnnotationsUsingSingleEcoIdReturnsResults() throws Exception {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3))
                 .andExpect(atLeastOneResultHasItem(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID));
     }
 
@@ -559,12 +548,11 @@ public class AnnotationControllerIT {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID + ","
                         + doc.ecoId + "," + NOTEXISTS_ECO_ID3));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 1))
+                .andExpect(totalNumOfResults(4))
                 .andExpect(fieldsInAllResultsExist(4))
-                .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID, NUMBER_OF_GENERIC_DOCS))
+                .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID, 3))
                 .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, doc.ecoId, 1))
                 .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, NOTEXISTS_ECO_ID3, 0));
     }
@@ -579,12 +567,11 @@ public class AnnotationControllerIT {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID)
                         .param(ECO_ID_PARAM, doc.ecoId).param(ECO_ID_PARAM, NOTEXISTS_ECO_ID3));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 1))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 1))
-                .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID, NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(4))
+                .andExpect(fieldsInAllResultsExist(4))
+                .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID, 3))
                 .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, doc.ecoId, 1))
                 .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, NOTEXISTS_ECO_ID3, 0));
     }
@@ -629,14 +616,13 @@ public class AnnotationControllerIT {
     public void pageRequestEqualToAvailablePagesReturns200() throws Exception {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(PAGE_PARAM, "1"));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
                 .andExpect(
                         pageInfoMatches(
                                 1,
-                                totalPages(NUMBER_OF_GENERIC_DOCS, DEFAULT_ENTRIES_PER_PAGE),
+                                totalPages(3, DEFAULT_ENTRIES_PER_PAGE),
                                 DEFAULT_ENTRIES_PER_PAGE)
                 );
     }
@@ -671,11 +657,10 @@ public class AnnotationControllerIT {
     public void successfulLookupWithFromForSingleId() throws Exception {
         ResultActions response =
                 mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM, "InterPro:IPR015421"));
-
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015421"));
 
     }
@@ -684,10 +669,9 @@ public class AnnotationControllerIT {
     public void successfulLookupWithFromForMultipleValues() throws Exception {
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM,
                 "InterPro:IPR015421,InterPro:IPR015422"));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015421"))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015422"));
 
@@ -705,11 +689,10 @@ public class AnnotationControllerIT {
     @Test
     public void successfulLookupWithFromUsingDatabaseNameOnly() throws Exception {
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM, "InterPro"));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015421"))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015422"));
     }
@@ -717,11 +700,10 @@ public class AnnotationControllerIT {
     @Test
     public void successfulLookupWithFromUsingDatabaseIdOnly() throws Exception {
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM, "IPR015421"));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015421"));
     }
 
@@ -741,9 +723,8 @@ public class AnnotationControllerIT {
     public void limitForPageWithinMaximumAllowed() throws Exception {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(LIMIT_PARAM, "100"));
-
         response.andExpect(status().isOk())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(3))
                 .andExpect(pageInfoMatches(1, 1, 100));
     }
 
@@ -777,13 +758,12 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM,
                 AnnotationDocMocker.REFERENCE));
-
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, NUMBER_OF_GENERIC_DOCS));
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3))
+                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, 3));
     }
 
     @Test
@@ -815,12 +795,11 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM,
                 AnnotationDocMocker.REFERENCE + "," + docA.reference + "," + docB.reference));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 2))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 2))
-                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(5))
+                .andExpect(fieldsInAllResultsExist(5))
+                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, 3))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docA.reference, 1))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docB.reference, 1));
     }
@@ -838,12 +817,11 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM,
                 AnnotationDocMocker.REFERENCE).param(REF_PARAM, docA.reference).param(REF_PARAM, docB.reference));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 2))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 2))
-                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(5))
+                .andExpect(fieldsInAllResultsExist(5))
+                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, 3))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docA.reference, 1))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docB.reference, 1));
     }
@@ -852,14 +830,13 @@ public class AnnotationControllerIT {
     public void filterByReferenceDbOnlyReturnsDocumentsWithReferencesThatStartWithThatDb() throws Exception {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM, "GO_REF"));
-
         //This one shouldn't be found
         AnnotationDocument docA = AnnotationDocMocker.createAnnotationDoc("A0A123");
         docA.reference = "PMID:0000002";
         repository.save(docA);
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS));
+                .andExpect(totalNumOfResults(3));
     }
 
     @Test
@@ -875,13 +852,12 @@ public class AnnotationControllerIT {
         AnnotationDocument docA = AnnotationDocMocker.createAnnotationDoc("A0A123");
         docA.reference = "PMID:0000002";
         repository.save(docA);
-
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM, "0000002"));
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 1))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 1))
-                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(4))
+                .andExpect(fieldsInAllResultsExist(4))
+                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, 3))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docA.reference, 1));
     }
 
@@ -897,12 +873,11 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM, "0000002")
                 .param(REF_PARAM, "0000003"));
-
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 2))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 2))
-                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, NUMBER_OF_GENERIC_DOCS))
+                .andExpect(totalNumOfResults(5))
+                .andExpect(fieldsInAllResultsExist(5))
+                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, 3))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docA.reference, 1))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docB.reference, 1));
     }
@@ -924,12 +899,11 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(GENE_PRODUCT_TYPE_PARAM,
                 "protein"));
-
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS));
+                .andExpect(totalNumOfResults(3))
+                .andExpect(fieldsInAllResultsExist(3));
     }
 
     @Test

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -70,6 +70,9 @@ public class AnnotationControllerIT {
     private static final String ECO_ID2 = "ECO:0000323";
     private static final String NOTEXISTS_ECO_ID3 = "ECO:0000888";
 
+    //Configuration
+    private static final int NUMBER_OF_GENERIC_DOCS = 3;
+
     private MockMvc mockMvc;
     private List<AnnotationDocument> genericDocs;
     @Autowired
@@ -85,8 +88,8 @@ public class AnnotationControllerIT {
         mockMvc = MockMvcBuilders.
                 webAppContextSetup(webApplicationContext)
                 .build();
-        final int numberOfGenericDocs = 3;
-        genericDocs = createGenericDocs(numberOfGenericDocs);
+
+        genericDocs = createGenericDocs(NUMBER_OF_GENERIC_DOCS);
         repository.save(genericDocs);
     }
 
@@ -264,10 +267,11 @@ public class AnnotationControllerIT {
         String goEvidenceCode = "IEA";
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GO_EVIDENCE_PARAM, goEvidenceCode));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
-                .andExpect(fieldsInAllResultsExist(3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
                 .andExpect(atLeastOneResultHasItem(GO_EVIDENCE_FIELD, goEvidenceCode));
     }
 
@@ -279,8 +283,8 @@ public class AnnotationControllerIT {
 
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
-                .andExpect(fieldsInAllResultsExist(3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
                 .andExpect(atLeastOneResultHasItem(GO_EVIDENCE_FIELD, goEvidenceCode.toUpperCase()));
     }
 
@@ -310,13 +314,14 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GO_EVIDENCE_PARAM, "IEA,BSS,AWE,PEG"));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(5))
-                .andExpect(fieldsInAllResultsExist(5))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 2))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 2))
                 .andExpect(itemExistsExpectedTimes(GO_EVIDENCE_FIELD, goEvidenceCode1, 1))
                 .andExpect(itemExistsExpectedTimes(GO_EVIDENCE_FIELD, goEvidenceCode2, 1))
-                .andExpect(itemExistsExpectedTimes(GO_EVIDENCE_FIELD, goEvidenceCode, 3));
+                .andExpect(itemExistsExpectedTimes(GO_EVIDENCE_FIELD, goEvidenceCode, NUMBER_OF_GENERIC_DOCS));
     }
 
     @Test
@@ -336,11 +341,12 @@ public class AnnotationControllerIT {
         String qualifier = "enables";
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(QUALIFIER_PARAM, qualifier));
+
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
-                .andExpect(fieldsInAllResultsExist(3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
                 .andExpect(valueOccurInField(QUALIFIER, qualifier));
 
     }
@@ -380,6 +386,7 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterByUniProtKBAndIntactAndRNACentralGeneProductIDSuccessfully() throws Exception {
+        repository.deleteAll();
         String uniprotGp = "A1E959";
         String intactGp = "EBI-10043081";
         String rnaGp = "URS00000064B1_559292";
@@ -390,6 +397,7 @@ public class AnnotationControllerIT {
         sj.add(uniprotGp).add(intactGp).add(rnaGp);
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GP_PARAM, sj.toString()));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
                 .andExpect(totalNumOfResults(3))
@@ -401,6 +409,7 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterByUniProtKBAndIntactAndRNACentralGeneProductIDCaseInsensitiveSuccessfully() throws Exception {
+        repository.deleteAll();
         String uniprotGp = "A1E959".toLowerCase();
         String intactGp = "EBI-10043081".toLowerCase();
         String rnaGp = "URS00000064B1_559292".toLowerCase();
@@ -411,6 +420,7 @@ public class AnnotationControllerIT {
         sj.add(uniprotGp).add(intactGp).add(rnaGp);
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GP_PARAM, sj.toString()));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
                 .andExpect(totalNumOfResults(3))
@@ -484,24 +494,26 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GO_ID_PARAM, AnnotationDocMocker.GO_ID));
+
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
-                .andExpect(fieldsInAllResultsExist(3))
-                .andExpect(itemExistsExpectedTimes(GO_ID, AnnotationDocMocker.GO_ID, 3));
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(itemExistsExpectedTimes(GO_ID, AnnotationDocMocker.GO_ID, NUMBER_OF_GENERIC_DOCS));
     }
 
     @Test
     public void successfullyLookupAnnotationsByGoIdCaseInsensitive() throws Exception {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(GO_ID_PARAM, AnnotationDocMocker.GO_ID.toLowerCase()));
+
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
-                .andExpect(fieldsInAllResultsExist(3))
-                .andExpect(itemExistsExpectedTimes(GO_ID, AnnotationDocMocker.GO_ID, 3));
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(itemExistsExpectedTimes(GO_ID, AnnotationDocMocker.GO_ID, NUMBER_OF_GENERIC_DOCS));
     }
 
     @Test
@@ -531,10 +543,11 @@ public class AnnotationControllerIT {
     public void filterAnnotationsUsingSingleEcoIdReturnsResults() throws Exception {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
-                .andExpect(fieldsInAllResultsExist(3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
                 .andExpect(atLeastOneResultHasItem(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID));
     }
 
@@ -548,11 +561,12 @@ public class AnnotationControllerIT {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID + ","
                         + doc.ecoId + "," + NOTEXISTS_ECO_ID3));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(4))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 1))
                 .andExpect(fieldsInAllResultsExist(4))
-                .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID, 3))
+                .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID, NUMBER_OF_GENERIC_DOCS))
                 .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, doc.ecoId, 1))
                 .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, NOTEXISTS_ECO_ID3, 0));
     }
@@ -567,11 +581,12 @@ public class AnnotationControllerIT {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID)
                         .param(ECO_ID_PARAM, doc.ecoId).param(ECO_ID_PARAM, NOTEXISTS_ECO_ID3));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(4))
-                .andExpect(fieldsInAllResultsExist(4))
-                .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID, 3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 1))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 1))
+                .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, AnnotationDocMocker.ECO_ID, NUMBER_OF_GENERIC_DOCS))
                 .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, doc.ecoId, 1))
                 .andExpect(itemExistsExpectedTimes(ECO_ID_PARAM, NOTEXISTS_ECO_ID3, 0));
     }
@@ -616,13 +631,14 @@ public class AnnotationControllerIT {
     public void pageRequestEqualToAvailablePagesReturns200() throws Exception {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(PAGE_PARAM, "1"));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
                 .andExpect(
                         pageInfoMatches(
                                 1,
-                                totalPages(3, DEFAULT_ENTRIES_PER_PAGE),
+                                totalPages(NUMBER_OF_GENERIC_DOCS, DEFAULT_ENTRIES_PER_PAGE),
                                 DEFAULT_ENTRIES_PER_PAGE)
                 );
     }
@@ -657,10 +673,11 @@ public class AnnotationControllerIT {
     public void successfulLookupWithFromForSingleId() throws Exception {
         ResultActions response =
                 mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM, "InterPro:IPR015421"));
+
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015421"));
 
     }
@@ -669,9 +686,10 @@ public class AnnotationControllerIT {
     public void successfulLookupWithFromForMultipleValues() throws Exception {
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM,
                 "InterPro:IPR015421,InterPro:IPR015422"));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015421"))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015422"));
 
@@ -689,10 +707,11 @@ public class AnnotationControllerIT {
     @Test
     public void successfulLookupWithFromUsingDatabaseNameOnly() throws Exception {
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM, "InterPro"));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
-                .andExpect(fieldsInAllResultsExist(3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015421"))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015422"));
     }
@@ -700,10 +719,11 @@ public class AnnotationControllerIT {
     @Test
     public void successfulLookupWithFromUsingDatabaseIdOnly() throws Exception {
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM, "IPR015421"));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
-                .andExpect(fieldsInAllResultsExist(3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
                 .andExpect(valueOccursInCollection(WITH_FROM, "InterPro:IPR015421"));
     }
 
@@ -723,8 +743,9 @@ public class AnnotationControllerIT {
     public void limitForPageWithinMaximumAllowed() throws Exception {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(LIMIT_PARAM, "100"));
+
         response.andExpect(status().isOk())
-                .andExpect(totalNumOfResults(3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
                 .andExpect(pageInfoMatches(1, 1, 100));
     }
 
@@ -758,12 +779,13 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM,
                 AnnotationDocMocker.REFERENCE));
+
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
-                .andExpect(fieldsInAllResultsExist(3))
-                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, 3));
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, NUMBER_OF_GENERIC_DOCS));
     }
 
     @Test
@@ -795,11 +817,12 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM,
                 AnnotationDocMocker.REFERENCE + "," + docA.reference + "," + docB.reference));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(5))
-                .andExpect(fieldsInAllResultsExist(5))
-                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, 3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 2))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 2))
+                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, NUMBER_OF_GENERIC_DOCS))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docA.reference, 1))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docB.reference, 1));
     }
@@ -817,11 +840,12 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM,
                 AnnotationDocMocker.REFERENCE).param(REF_PARAM, docA.reference).param(REF_PARAM, docB.reference));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(5))
-                .andExpect(fieldsInAllResultsExist(5))
-                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, 3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 2))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 2))
+                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, NUMBER_OF_GENERIC_DOCS))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docA.reference, 1))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docB.reference, 1));
     }
@@ -830,13 +854,14 @@ public class AnnotationControllerIT {
     public void filterByReferenceDbOnlyReturnsDocumentsWithReferencesThatStartWithThatDb() throws Exception {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM, "GO_REF"));
+
         //This one shouldn't be found
         AnnotationDocument docA = AnnotationDocMocker.createAnnotationDoc("A0A123");
         docA.reference = "PMID:0000002";
         repository.save(docA);
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3));
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS));
     }
 
     @Test
@@ -852,12 +877,13 @@ public class AnnotationControllerIT {
         AnnotationDocument docA = AnnotationDocMocker.createAnnotationDoc("A0A123");
         docA.reference = "PMID:0000002";
         repository.save(docA);
+
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM, "0000002"));
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(4))
-                .andExpect(fieldsInAllResultsExist(4))
-                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, 3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 1))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 1))
+                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, NUMBER_OF_GENERIC_DOCS))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docA.reference, 1));
     }
 
@@ -873,11 +899,12 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM, "0000002")
                 .param(REF_PARAM, "0000003"));
+
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(5))
-                .andExpect(fieldsInAllResultsExist(5))
-                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, 3))
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 2))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 2))
+                .andExpect(itemExistsExpectedTimes(REFERENCE, AnnotationDocMocker.REFERENCE, NUMBER_OF_GENERIC_DOCS))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docA.reference, 1))
                 .andExpect(itemExistsExpectedTimes(REFERENCE, docB.reference, 1));
     }
@@ -899,11 +926,12 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(GENE_PRODUCT_TYPE_PARAM,
                 "protein"));
+
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(3))
-                .andExpect(fieldsInAllResultsExist(3));
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS));
     }
 
     @Test

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -400,7 +400,32 @@ public class AnnotationControllerIT {
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
                 .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS));
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, uniprotGp, 1))
+                .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, intactGp, 1))
+                .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, rnaGp, 1));
+    }
+
+    @Test
+    public void filterByUniProtKBAndIntactAndRNACentralGeneProductIDCaseInsensitiveSuccessfully() throws Exception {
+        String uniprotGp = "A1E959".toLowerCase();
+        String intactGp = "EBI-10043081".toLowerCase();
+        String rnaGp = "URS00000064B1_559292".toLowerCase();
+        repository.save(AnnotationDocMocker.createAnnotationDoc(uniprotGp));
+        repository.save(AnnotationDocMocker.createAnnotationDoc(intactGp));
+        repository.save(AnnotationDocMocker.createAnnotationDoc(rnaGp));
+        StringJoiner sj = new StringJoiner(",");
+        sj.add(uniprotGp).add(intactGp).add(rnaGp);
+        ResultActions response = mockMvc.perform(
+                get(RESOURCE_URL + "/search").param(GP_PARAM, sj.toString()));
+
+        response.andExpect(status().isOk())
+                .andExpect(contentTypeToBeJson())
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, uniprotGp, 1))
+                .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, intactGp, 1))
+                .andExpect(itemExistsExpectedTimes(GENE_PRODUCT_ID, rnaGp, 1));
     }
 
     @Test

--- a/common/src/main/java/uk/ac/ebi/quickgo/common/loader/DbXRefLoader.java
+++ b/common/src/main/java/uk/ac/ebi/quickgo/common/loader/DbXRefLoader.java
@@ -4,6 +4,7 @@ import uk.ac.ebi.quickgo.common.validator.DbXRefEntity;
 
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
@@ -33,6 +34,9 @@ public class DbXRefLoader {
     private final Logger logger = LoggerFactory.getLogger(DbXRefLoader.class);
     private final String path;
 
+    private static final boolean POSTGRES = true;
+    protected boolean compress = true;
+
     public DbXRefLoader(String path) {
         this.path = path;
     }
@@ -58,7 +62,8 @@ public class DbXRefLoader {
                     .skip(1)    //header
                     .map(line -> line.split(COL_DELIMITER))
                     .map(fields -> new DbXRefEntity(fields[COL_DATABASE], fields[COL_ENTITY_TYPE],
-                            fields[COL_ENTITY_TYPE_NAME], fields[COL_LOCAL_ID_SYNTAX], fields[COL_URL_SYNTAX]))
+                            fields[COL_ENTITY_TYPE_NAME], directRead(fields[COL_LOCAL_ID_SYNTAX]),
+                            fields[COL_URL_SYNTAX]))
                     .collect(toList());
 
         } catch (Exception e) {
@@ -69,5 +74,85 @@ public class DbXRefLoader {
         }
 
     }
+
+    public String directRead(String input)  {
+        StringBuilder field = new StringBuilder();
+        List<String> data = new ArrayList<String>();
+        String line;
+        data.clear();
+        boolean isNull = false;
+
+        int count = 0;
+//        line = rd.readLine();
+        if (input == null) {
+//            eof = true;
+            return "";
+        }
+
+//        field.setLength(0);
+        boolean escape = false;
+
+        while (count < input.length()) {
+            char ch = input.charAt(count);
+            if (escape) {
+                if (ch == 't') {
+                    field.append('\t');
+                }
+                else if (ch == 'n') {
+                    field.append('\n');
+                }
+                else if (ch == 'N') {
+                    isNull = true;
+                }
+                else if (ch == '\\') {
+                    field.append('\\');
+                }
+                escape = false;
+            }
+            // Not currently escaped
+            else {
+                if (ch == '\\' && POSTGRES) {
+                    escape = true;
+                }
+                //Neither escaped nor postgres
+                else {
+                    if (ch == '\t') {
+                        if (isNull) {
+                            data.add(null);
+                        }
+                        else {
+                            //data.add(field.toString());
+                            return field.toString();
+                        }
+//                        field.setLength(0);
+                        isNull = false;
+                    }
+                    else {
+                        field.append(ch);
+                    }
+                }
+
+            }
+            count++;
+
+//            if (count == line.length() && escape) {
+//                line = rd.readLine();
+//                if (line == null) {
+//                    break;
+//                }
+//                count = 0;
+//                escape = false;
+//            }
+        }
+
+//        if (isNull){
+//            data.add(null);
+//        }
+//        else {
+//            data.add(field.toString());
+//        }
+        return field.toString();
+    }
+
 
 }

--- a/common/src/main/java/uk/ac/ebi/quickgo/common/loader/DbXRefLoader.java
+++ b/common/src/main/java/uk/ac/ebi/quickgo/common/loader/DbXRefLoader.java
@@ -4,6 +4,7 @@ import uk.ac.ebi.quickgo.common.validator.DbXRefEntity;
 
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
@@ -33,12 +34,11 @@ public class DbXRefLoader {
     private final Logger logger = LoggerFactory.getLogger(DbXRefLoader.class);
     private final String path;
     private final boolean caseSensitive;
-
-    public DbXRefLoader(String path, boolean caseSensitive) {
     private static final boolean POSTGRES = true;
     protected boolean compress = true;
 
-    public DbXRefLoader(String path) {
+    public DbXRefLoader(String path, boolean caseSensitive) {
+
         this.path = path;
         this.caseSensitive = caseSensitive;
     }
@@ -52,6 +52,8 @@ public class DbXRefLoader {
      *
      * If the file cannot be loaded supply the client with an empty list, as we will continue without
      * validation, rather than end the process.
+     *
+     * Use directRead(fields[COL_LOCAL_ID_SYNTAX])?
      * @return a list of GeneProductDbXRefIDFormat instances that hold the validation regular expressions.
      */
     public List<DbXRefEntity> load() {

--- a/common/src/main/java/uk/ac/ebi/quickgo/common/loader/DbXRefLoader.java
+++ b/common/src/main/java/uk/ac/ebi/quickgo/common/loader/DbXRefLoader.java
@@ -4,7 +4,6 @@ import uk.ac.ebi.quickgo.common.validator.DbXRefEntity;
 
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
@@ -34,8 +33,6 @@ public class DbXRefLoader {
     private final Logger logger = LoggerFactory.getLogger(DbXRefLoader.class);
     private final String path;
     private final boolean caseSensitive;
-    private static final boolean POSTGRES = true;
-    protected boolean compress = true;
 
     public DbXRefLoader(String path, boolean caseSensitive) {
 
@@ -52,8 +49,6 @@ public class DbXRefLoader {
      *
      * If the file cannot be loaded supply the client with an empty list, as we will continue without
      * validation, rather than end the process.
-     *
-     * Use directRead(fields[COL_LOCAL_ID_SYNTAX])?
      * @return a list of GeneProductDbXRefIDFormat instances that hold the validation regular expressions.
      */
     public List<DbXRefEntity> load() {
@@ -78,85 +73,5 @@ public class DbXRefLoader {
         }
 
     }
-
-    public String directRead(String input)  {
-        StringBuilder field = new StringBuilder();
-        List<String> data = new ArrayList<String>();
-        String line;
-        data.clear();
-        boolean isNull = false;
-
-        int count = 0;
-//        line = rd.readLine();
-        if (input == null) {
-//            eof = true;
-            return "";
-        }
-
-//        field.setLength(0);
-        boolean escape = false;
-
-        while (count < input.length()) {
-            char ch = input.charAt(count);
-            if (escape) {
-                if (ch == 't') {
-                    field.append('\t');
-                }
-                else if (ch == 'n') {
-                    field.append('\n');
-                }
-                else if (ch == 'N') {
-                    isNull = true;
-                }
-                else if (ch == '\\') {
-                    field.append('\\');
-                }
-                escape = false;
-            }
-            // Not currently escaped
-            else {
-                if (ch == '\\' && POSTGRES) {
-                    escape = true;
-                }
-                //Neither escaped nor postgres
-                else {
-                    if (ch == '\t') {
-                        if (isNull) {
-                            data.add(null);
-                        }
-                        else {
-                            //data.add(field.toString());
-                            return field.toString();
-                        }
-//                        field.setLength(0);
-                        isNull = false;
-                    }
-                    else {
-                        field.append(ch);
-                    }
-                }
-
-            }
-            count++;
-
-//            if (count == line.length() && escape) {
-//                line = rd.readLine();
-//                if (line == null) {
-//                    break;
-//                }
-//                count = 0;
-//                escape = false;
-//            }
-        }
-
-//        if (isNull){
-//            data.add(null);
-//        }
-//        else {
-//            data.add(field.toString());
-//        }
-        return field.toString();
-    }
-
 
 }


### PR DESCRIPTION
I've added a test for case sensitivity for RNA, Intact and UniProt gene product ids. When loading the validation regexes in from file they work fine, which is why the jira request for the branch is closed, but this test proves this.