### PR TITLE
GOA-2139_Add_parent_relation_to_child_term

### DIFF
--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/ontology/converter/GOTermToODocConverter.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/ontology/converter/GOTermToODocConverter.java
@@ -34,7 +34,6 @@ public class GOTermToODocConverter implements Function<Optional<GOTerm>, Optiona
             doc.annotationGuidelines = extractAnnGuidelines(term);
             doc.aspect = term.getAspect() == null ?
                     null : term.getAspect().text;
-            doc.children = extractChildren(term);
             doc.taxonConstraints = extractTaxonConstraints(term);
             doc.usage = term.getUsage() == null ?
                     null : term.getUsage().getText();
@@ -44,17 +43,6 @@ public class GOTermToODocConverter implements Function<Optional<GOTerm>, Optiona
             return Optional.of(doc);
         } else {
             return Optional.empty();
-        }
-    }
-
-    protected List<String> extractChildren(GOTerm goTerm) {
-        if (!isEmpty(goTerm.getChildren())) {
-            return goTerm.getChildren().stream()
-                    .map(
-                            t -> t.getChild().getId())
-                    .collect(Collectors.toList());
-        } else {
-            return null;
         }
     }
 

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/ontology/converter/GOTermToODocConverterTest.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/ontology/converter/GOTermToODocConverterTest.java
@@ -1,10 +1,5 @@
 package uk.ac.ebi.quickgo.index.ontology.converter;
 
-import uk.ac.ebi.quickgo.common.converter.FlatField;
-import uk.ac.ebi.quickgo.index.ontology.converter.GOTermToODocConverter;
-import uk.ac.ebi.quickgo.model.ontology.generic.GenericTerm;
-import uk.ac.ebi.quickgo.model.ontology.generic.RelationType;
-import uk.ac.ebi.quickgo.model.ontology.generic.TermRelation;
 import uk.ac.ebi.quickgo.model.ontology.go.GOTerm;
 import uk.ac.ebi.quickgo.model.ontology.go.GOTermBlacklist;
 import uk.ac.ebi.quickgo.model.ontology.go.TaxonConstraint;
@@ -63,30 +58,6 @@ public class GOTermToODocConverterTest {
     public void extractsAnnGuideLinesWhenNotExists() {
         when(term.getGuidelines()).thenReturn(null);
         assertThat(converter.extractAnnGuidelines(term), is(nullValue()));
-    }
-
-    // children
-    @Test
-    public void extractsChildrenWhenExists() {
-        GenericTerm childTermMock = mock(GenericTerm.class);
-        when(childTermMock.getId()).thenReturn("child1");
-
-        TermRelation childRel = new TermRelation(childTermMock, term, RelationType.ISA);
-        List<TermRelation> children = Collections.singletonList(childRel);
-
-        when(term.getChildren()).thenReturn(children);
-
-        List<String> childrenStrList = converter.extractChildren(term);
-        assertThat(childrenStrList, is(not(nullValue())));
-        assertThat(childrenStrList.size(), is(1));
-        assertThat(childrenStrList.get(0).contains("child1"), is(true));
-        System.out.println(childrenStrList.get(0));
-    }
-
-    @Test
-    public void extractsChildrenWhenNotExists() {
-        when(term.getChildren()).thenReturn(null);
-        assertThat(converter.extractChildren(term), is(nullValue()));
     }
 
     // taxon constraints

--- a/ontology-common/src/main/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyDocument.java
+++ b/ontology-common/src/main/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyDocument.java
@@ -55,9 +55,6 @@ public class OntologyDocument implements QuickGODocument {
     @Field(OntologyFields.REPLACES)
     public List<String> replaces;
 
-    @Field(OntologyFields.CHILDREN)
-    public List<String> children;
-
     @Field(OntologyFields.ASPECT)
     public String aspect;
 
@@ -136,9 +133,6 @@ public class OntologyDocument implements QuickGODocument {
         if (replacements != null ? !replacements.equals(that.replacements) : that.replacements != null) {
             return false;
         }
-        if (children != null ? !children.equals(that.children) : that.children != null) {
-            return false;
-        }
         if (aspect != null ? !aspect.equals(that.aspect) : that.aspect != null) {
             return false;
         }
@@ -182,7 +176,6 @@ public class OntologyDocument implements QuickGODocument {
         result = 31 * result + (subsets != null ? subsets.hashCode() : 0);
         result = 31 * result + (replaces != null ? replaces.hashCode() : 0);
         result = 31 * result + (replacements != null ? replacements.hashCode() : 0);
-        result = 31 * result + (children != null ? children.hashCode() : 0);
         result = 31 * result + (aspect != null ? aspect.hashCode() : 0);
         result = 31 * result + (history != null ? history.hashCode() : 0);
         result = 31 * result + (xrefs != null ? xrefs.hashCode() : 0);
@@ -209,7 +202,6 @@ public class OntologyDocument implements QuickGODocument {
                 ", subsets=" + subsets +
                 ", replaces='" + replaces +
                 ", replacements=" + replacements +
-                ", children=" + children +
                 ", aspect=" + aspect +
                 ", history=" + history +
                 ", xrefs=" + xrefs +

--- a/ontology-common/src/test/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyDocMocker.java
+++ b/ontology-common/src/test/java/uk/ac/ebi/quickgo/ontology/common/document/OntologyDocMocker.java
@@ -87,7 +87,6 @@ public final class OntologyDocMocker {
         od.isObsolete = true;
         od.comment = "Note that protein targeting encompasses the transport of the protein to " +
                 "the specified location, and may also include additional steps such as protein processing.";
-        od.children = Arrays.asList("GO:0000011", "GO:0000012");
         od.synonymNames = Arrays.asList("creatine anabolism", "crayola testarossa");
         od.secondaryIds = Arrays.asList("GO:0000003", "GO:0000004");
         od.subsets = Arrays.asList("goslim_pombe",

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/OBOTerm.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/OBOTerm.java
@@ -48,7 +48,7 @@ public class OBOTerm {
     public List<String> subsets;
 
     // list of term IDs that are children of this term
-    public List<String> children;
+    public List<Relation> children;
 
     public List<String> secondaryIds;
 
@@ -125,6 +125,12 @@ public class OBOTerm {
     public static class Replace implements FieldType {
         public String id;
         public String type;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class Relation implements FieldType {
+        public String id;
+        public OntologyRelationType relation;
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/OntologyServiceImpl.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/OntologyServiceImpl.java
@@ -141,7 +141,7 @@ public class OntologyServiceImpl<T extends OBOTerm> implements OntologyService<T
      *
      * <p>No ontology graph data is added to the {@link OntologyDocument}s.
      *
-     * @param docs the list od {@link OntologyDocument}s to convert
+     * @param docs the list od {@link OntologyDocument}s to convertRelation
      * @return a {@link Stream} of {@link T} instances
      */
     private Stream<T> convertDocs(List<OntologyDocument> docs) {
@@ -161,7 +161,7 @@ public class OntologyServiceImpl<T extends OBOTerm> implements OntologyService<T
             Set<OntologyRelationship> childrenEdges = ontologyTraversal.children(term.id);
 
             term.children = childrenEdges.stream()
-                    .map(this::convert)
+                    .map(this::convertRelation)
                     .collect(Collectors.toList());
         } catch (IllegalArgumentException e) {
             LOGGER.info("Could not fetch children for: [" + term.id + "]. Exception message was: " + e.getMessage());
@@ -173,10 +173,10 @@ public class OntologyServiceImpl<T extends OBOTerm> implements OntologyService<T
     /**
      * Converts an edge {@link OntologyRelationType} into an {@link uk.ac.ebi.quickgo.ontology.model.OBOTerm.Relation}.
      *
-     * @param oRel the ontology relationship to convert
+     * @param oRel the ontology relationship to convertRelation
      * @return an ontology relation understandable by the client
      */
-    private OBOTerm.Relation convert(OntologyRelationship oRel) {
+    private OBOTerm.Relation convertRelation(OntologyRelationship oRel) {
         OBOTerm.Relation relation = new OBOTerm.Relation();
         relation.id = oRel.child;
         relation.relation = oRel.relationship;

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/OntologyServiceImpl.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/OntologyServiceImpl.java
@@ -146,7 +146,42 @@ public class OntologyServiceImpl<T extends OBOTerm> implements OntologyService<T
      */
     private Stream<T> convertDocs(List<OntologyDocument> docs) {
         return docs.stream()
-                .map(converter::convert);
+                .map(converter::convert)
+                .map(this::insertChildren);
+    }
+
+    /**
+     * Looks up the children of the {@code term} and adds them to the term.
+     *
+     * @param term
+     * @return
+     */
+    private T insertChildren(T term) {
+        try {
+            Set<OntologyRelationship> childrenEdges = ontologyTraversal.children(term.id);
+
+            term.children = childrenEdges.stream()
+                    .map(this::convert)
+                    .collect(Collectors.toList());
+        } catch (IllegalArgumentException e) {
+            LOGGER.info("Could not fetch children for: [" + term.id + "]. Exception message was: " + e.getMessage());
+        }
+
+        return term;
+    }
+
+    /**
+     * Converts an edge {@link OntologyRelationType} into an {@link uk.ac.ebi.quickgo.ontology.model.OBOTerm.Relation}.
+     *
+     * @param oRel the ontology relationship to convert
+     * @return an ontology relation understandable by the client
+     */
+    private OBOTerm.Relation convert(OntologyRelationship oRel) {
+        OBOTerm.Relation relation = new OBOTerm.Relation();
+        relation.id = oRel.child;
+        relation.relation = oRel.relationship;
+
+        return relation;
     }
 
     private T insertAncestors(T term, OntologyRelationType... relations) {
@@ -176,7 +211,7 @@ public class OntologyServiceImpl<T extends OBOTerm> implements OntologyService<T
         try {
             return traversalFunction.apply(term, relations);
         } catch (Exception e) {
-            LOGGER.debug("Could not fetch relatives for: [" + term.id + "] with relationships: ["
+            LOGGER.info("Could not fetch relatives for: [" + term.id + "] with relationships: ["
                     + Stream.of(relations).map(OntologyRelationType::getLongName).collect(Collectors.joining(","))
                     + "]. Exception message was: " + e.getMessage());
             return Collections.unmodifiableList(Collections.emptyList());
@@ -191,8 +226,7 @@ public class OntologyServiceImpl<T extends OBOTerm> implements OntologyService<T
 
         List<T> entryHits = pagedResult.getContent().stream()
                 .map(converter::convert)
-                .map(this::insertAncestors)
-                .map(this::insertDescendants)
+                .map(this::insertChildren)
                 .collect(Collectors.toList());
 
         return new QueryResult.Builder<>(totalNumberOfHits, entryHits).withPageInfo(pageInfo).build();

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/AbstractODocConverter.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/AbstractODocConverter.java
@@ -39,7 +39,6 @@ abstract class AbstractODocConverter<T extends OBOTerm> implements OntologyDocCo
         term.name = ontologyDocument.name;
         term.isObsolete = ontologyDocument.isObsolete;
         term.comment = ontologyDocument.comment;
-        term.children = ontologyDocument.children;
         term.secondaryIds = ontologyDocument.secondaryIds;
         term.subsets = ontologyDocument.subsets;
         term.definition = DEFINITION_CONVERTER.apply(ontologyDocument);

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/ReplaceConverter.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/converter/ReplaceConverter.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * @author Ricardo Antunes
  */
-public class ReplaceConverter implements FieldConverter<OBOTerm.Replace> {
+class ReplaceConverter implements FieldConverter<OBOTerm.Replace> {
     private static final Logger logger = LoggerFactory.getLogger(ReplaceConverter.class);
 
     private static final int FIELD_COUNT = 2;

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/traversal/OntologyGraph.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/traversal/OntologyGraph.java
@@ -125,6 +125,17 @@ public class OntologyGraph implements OntologyGraphTraversal {
         return ancestorsFound.stream().collect(Collectors.toList());
     }
 
+    @Override public Set<OntologyRelationship> parents(String baseVertex, OntologyRelationType... relations) {
+        Preconditions.checkArgument(baseVertex != null && !baseVertex.trim().isEmpty(),
+                "Base vertex cannot be null or empty");
+
+        Set<OntologyRelationType> relationsSet = createRelevantRelationsSet(relations);
+
+        return ontology.outgoingEdgesOf(baseVertex).stream()
+                .filter(ontologyRelationship -> relationsSet.contains(ontologyRelationship.relationship))
+                .collect(Collectors.toSet());
+    }
+
     @Override
     public List<String> descendants(Set<String> topVertices, OntologyRelationType... relations) {
         Preconditions.checkArgument(!isNullOrEmpty(topVertices), "Top vertices cannot be null/empty.");
@@ -135,6 +146,17 @@ public class OntologyGraph implements OntologyGraphTraversal {
         Set<OntologyRelationType> relationsSet = createRelevantRelationsSet(relations);
         descendants(topVertices, descendantsFound, relationsSet);
         return descendantsFound.stream().collect(Collectors.toList());
+    }
+
+    @Override public Set<OntologyRelationship> children(String topVertex, OntologyRelationType... relations) {
+        Preconditions.checkArgument(topVertex != null && !topVertex.trim().isEmpty(),
+                "Top vertex cannot be null or empty");
+
+        Set<OntologyRelationType> relationsSet = createRelevantRelationsSet(relations);
+
+        return ontology.incomingEdgesOf(topVertex).stream()
+                .filter(ontologyRelationship -> relationsSet.contains(ontologyRelationship.relationship))
+                .collect(Collectors.toSet());
     }
 
     @Override public int hashCode() {

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/traversal/OntologyGraphTraversal.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/traversal/OntologyGraphTraversal.java
@@ -48,6 +48,7 @@ public interface OntologyGraphTraversal {
      * @param relations the relations that a parent vertex has with its child
      * @return a set of {@link OntologyRelationship} relationships between the {@code baseVertex} and the retrieved
      * parent vertices
+     * @throws IllegalArgumentException if the {@code baseVertex} is null, empty or does not exist in the graph
      */
     Set<OntologyRelationship> parents(String baseVertex, OntologyRelationType... relations);
 
@@ -71,6 +72,7 @@ public interface OntologyGraphTraversal {
      * @param relations the relations that a child vertex has with its parent
      * @return a set of {@link OntologyRelationship} relationships between the {@code topVertex} and the retrieved
      * child vertices
+     * @throws IllegalArgumentException if the {@code topVertex} is null, empty or does not exist in the graph
      */
     Set<OntologyRelationship> children(String topVertex, OntologyRelationType... relations);
 }

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/traversal/OntologyGraphTraversal.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/traversal/OntologyGraphTraversal.java
@@ -40,6 +40,18 @@ public interface OntologyGraphTraversal {
     List<String> ancestors(Set<String> baseVertices, OntologyRelationType... relations);
 
     /**
+     * Finds a set of all the parent vertices of the {@code baseVertex} that fulfill the provided {@code relations}.
+     * <p/>
+     * <b>Note:</b> If no relations are provided, it is assumed that all relations will be searched for.
+     *
+     * @param baseVertex the vertex whose parents are to be retrieved
+     * @param relations the relations that a parent vertex has with its child
+     * @return a set of {@link OntologyRelationship} relationships between the {@code baseVertex} and the retrieved
+     * parent vertices
+     */
+    Set<OntologyRelationship> parents(String baseVertex, OntologyRelationType... relations);
+
+    /**
      * Find the set of descendant vertices reachable from a top vertex, navigable via a specified
      * set of relations.
      *
@@ -49,4 +61,16 @@ public interface OntologyGraphTraversal {
      * @return the list of descendant vertices.
      */
     List<String> descendants(Set<String> topVertices, OntologyRelationType... relations);
+
+    /**
+     * Finds a set of all the child vertices of the {@code topVertex} that fulfill the provided {@code relations}.
+     * <p/>
+     * <b>Note:</b> If no relations are provided, it is assumed that all relations will be searched for.
+     *
+     * @param topVertex the vertex whose children are to be retrieved
+     * @param relations the relations that a child vertex has with its parent
+     * @return a set of {@link OntologyRelationship} relationships between the {@code topVertex} and the retrieved
+     * child vertices
+     */
+    Set<OntologyRelationship> children(String topVertex, OntologyRelationType... relations);
 }

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
@@ -9,7 +9,6 @@ import uk.ac.ebi.quickgo.ontology.model.OntologyRelationship;
 import uk.ac.ebi.quickgo.ontology.traversal.OntologyGraph;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.Before;
@@ -54,8 +53,6 @@ public abstract class OBOControllerIT {
     // temporary data store for solr's data, which is automatically cleaned on exit
     @ClassRule
     public static final TemporarySolrDataStore solrDataStore = new TemporarySolrDataStore();
-
-    static final String COMMA = ",";
 
     private static final String QUERY_PARAM = "query";
     private static final String PAGE_PARAM = "page";
@@ -527,6 +524,15 @@ public abstract class OBOControllerIT {
     }
 
     @Test
+    public void canFetchChildrenFromTerm() throws Exception {
+        ResultActions response = mockMvc.perform( get(buildTermsURL()));
+
+        response.andDo(print())
+                .andExpect(jsonPath("$.numberOfHits").value(validIdList.size()))
+                .andExpect(jsonPath("$.results.*.children").exists());
+    }
+
+    @Test
     public void invalidDescendantsProduces400AndErrorMessage() throws Exception {
         ResultActions response = mockMvc.perform(
                 get(buildTermsURLWithSubResource(invalidId(), DESCENDANTS_SUB_RESOURCE)));
@@ -710,7 +716,6 @@ public abstract class OBOControllerIT {
 
     protected ResultActions expectCompleteFields(ResultActions result, String id, String path) throws Exception {
         return expectCoreFields(result, id, path)
-                .andExpect(jsonPath(path + "children").exists())
                 .andExpect(jsonPath(path + "secondaryIds").exists())
                 .andExpect(jsonPath(path + "history").exists())
                 .andExpect(jsonPath(path + "xRefs").exists())
@@ -780,6 +785,8 @@ public abstract class OBOControllerIT {
         invalidRelation = "this-does-not-exist";
         ontologyGraph.addRelationships(simpleRelationships);
     }
+
+
 
     private String requestUrl(ResultActions resultActions) {
         return resultActions.andReturn().getRequest().getRequestURL().toString();

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/service/converter/AbstractODocConverterTest.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/service/converter/AbstractODocConverterTest.java
@@ -57,11 +57,6 @@ public class AbstractODocConverterTest {
     }
 
     @Test
-    public void convertsChildrenWithoutError() {
-        assertThat(oboTermFromValidGODoc.children, is(validGODoc.children));
-    }
-
-    @Test
     public void convertsCommentWithoutError() {
         assertThat(oboTermFromValidGODoc.comment, is(validGODoc.comment));
     }

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/traversal/OntologyGraphTest.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/traversal/OntologyGraphTest.java
@@ -549,20 +549,20 @@ public class OntologyGraphTest {
         private final String parentId = id("1");
 
         private final OntologyRelationship grandParentIsA = createRelationship(parentId, id("0"), IS_A);
-        private final OntologyRelationship childOf1IsA = createRelationship(id("2"), parentId, IS_A);
-        private final OntologyRelationship childOf1HasPart1 = createRelationship(id("3"), parentId, HAS_PART);
-        private final OntologyRelationship childOf1HasPart2 = createRelationship(id("4"), parentId, HAS_PART);
-        private final OntologyRelationship childOf1Regulates = createRelationship(id("5"), parentId, REGULATES);
+        private final OntologyRelationship childIsA = createRelationship(id("2"), parentId, IS_A);
+        private final OntologyRelationship childHasPart1 = createRelationship(id("3"), parentId, HAS_PART);
+        private final OntologyRelationship childHasPart2 = createRelationship(id("4"), parentId, HAS_PART);
+        private final OntologyRelationship childRegulates = createRelationship(id("5"), parentId, REGULATES);
         private final OntologyRelationship grandChildIsA = createRelationship(id("6"), id("2"), IS_A);
 
         @Before
         public void populateOntology() {
             ontologyGraph.addRelationships(asList(
                     grandParentIsA,
-                    childOf1IsA,
-                    childOf1HasPart1,
-                    childOf1HasPart2,
-                    childOf1Regulates,
+                    childIsA,
+                    childHasPart1,
+                    childHasPart2,
+                    childRegulates,
                     grandChildIsA
             ));
         }
@@ -581,22 +581,21 @@ public class OntologyGraphTest {
         public void finds1IsAChildOfParent1() throws Exception {
             Set<OntologyRelationship> expectedChildren = ontologyGraph.children(parentId, IS_A);
 
-            assertThat(expectedChildren, contains(childOf1IsA));
+            assertThat(expectedChildren, contains(childIsA));
         }
 
         @Test
         public void finds2HasPartChildrenOfParent1() throws Exception {
             Set<OntologyRelationship> expectedChildren = ontologyGraph.children(parentId, HAS_PART);
 
-            assertThat(expectedChildren, containsInAnyOrder(childOf1HasPart1, childOf1HasPart2));
+            assertThat(expectedChildren, containsInAnyOrder(childHasPart1, childHasPart2));
         }
 
         @Test
         public void findsAllChildrenOfParent1WithoutAnyRelationshipsSetAsArguments() throws Exception {
             Set<OntologyRelationship> expectedChildren = ontologyGraph.children(parentId);
 
-            assertThat(expectedChildren,
-                    containsInAnyOrder(childOf1HasPart1, childOf1HasPart2, childOf1IsA, childOf1Regulates));
+            assertThat(expectedChildren, containsInAnyOrder(childHasPart1, childHasPart2, childIsA, childRegulates));
         }
 
         @Test
@@ -619,22 +618,22 @@ public class OntologyGraphTest {
     public class ParentTests {
         private final String childId = id("1");
 
-        private final OntologyRelationship parentIsAOfChild1 = createRelationship(childId, id("2"), IS_A);
-        private final OntologyRelationship parentHasPart1OfChild1 = createRelationship(childId, id("3"), HAS_PART);
-        private final OntologyRelationship parentHasPart2OfChild1 = createRelationship(childId, id("4"), HAS_PART);
-        private final OntologyRelationship parentRegulatesOfChild1 = createRelationship(childId, id("5"), REGULATES);
-        private final OntologyRelationship childIsAOfChild1 = createRelationship(id("6"), childId, REGULATES);
-        private final OntologyRelationship grandParentHasPartOfChild1 = createRelationship(id("7"), id("3"), REGULATES);
+        private final OntologyRelationship parentIsA = createRelationship(childId, id("2"), IS_A);
+        private final OntologyRelationship parentHasPart1 = createRelationship(childId, id("3"), HAS_PART);
+        private final OntologyRelationship parentHasPart2 = createRelationship(childId, id("4"), HAS_PART);
+        private final OntologyRelationship parentRegulates = createRelationship(childId, id("5"), REGULATES);
+        private final OntologyRelationship childIsA = createRelationship(id("6"), childId, REGULATES);
+        private final OntologyRelationship grandParentHasPart = createRelationship(id("7"), id("3"), REGULATES);
 
         @Before
         public void populateOntology() {
             ontologyGraph.addRelationships(asList(
-                    parentIsAOfChild1,
-                    parentHasPart1OfChild1,
-                    parentHasPart2OfChild1,
-                    parentRegulatesOfChild1,
-                    childIsAOfChild1,
-                    grandParentHasPartOfChild1
+                    parentIsA,
+                    parentHasPart1,
+                    parentHasPart2,
+                    parentRegulates,
+                    childIsA,
+                    grandParentHasPart
             ));
         }
 
@@ -652,23 +651,21 @@ public class OntologyGraphTest {
         public void finds1IsAParentOfChild1() throws Exception {
             Set<OntologyRelationship> expectedParents = ontologyGraph.parents(childId, IS_A);
 
-            assertThat(expectedParents, contains(parentIsAOfChild1));
+            assertThat(expectedParents, contains(parentIsA));
         }
 
         @Test
         public void finds2HasPartParentsOfChild1() throws Exception {
             Set<OntologyRelationship> expectedParents = ontologyGraph.parents(childId, HAS_PART);
 
-            assertThat(expectedParents, containsInAnyOrder(parentHasPart1OfChild1, parentHasPart2OfChild1));
+            assertThat(expectedParents, containsInAnyOrder(parentHasPart1, parentHasPart2));
         }
 
         @Test
         public void findsAllParentsOfChild1WithoutAnyRelationshipsSetAsArguments() throws Exception {
             Set<OntologyRelationship> expectedParents = ontologyGraph.parents(childId);
 
-            assertThat(expectedParents,
-                    containsInAnyOrder(parentIsAOfChild1, parentHasPart1OfChild1, parentHasPart2OfChild1,
-                            parentRegulatesOfChild1));
+            assertThat(expectedParents, containsInAnyOrder(parentIsA, parentHasPart1, parentHasPart2, parentRegulates));
         }
 
         @Test
@@ -676,7 +673,7 @@ public class OntologyGraphTest {
             Set<OntologyRelationship> expectedParents = ontologyGraph.parents(childId);
 
             assertThat(expectedParents, hasSize(4));
-            assertThat(expectedParents, not(hasItem(childIsAOfChild1)));
+            assertThat(expectedParents, not(hasItem(childIsA)));
         }
 
         @Test
@@ -684,7 +681,7 @@ public class OntologyGraphTest {
             Set<OntologyRelationship> expectedParents = ontologyGraph.parents(childId);
 
             assertThat(expectedParents, hasSize(4));
-            assertThat(expectedParents, not(hasItem(grandParentHasPartOfChild1)));
+            assertThat(expectedParents, not(hasItem(grandParentHasPart)));
         }
     }
 }

--- a/solr-cores/src/main/cores/ontology/conf/schema.xml
+++ b/solr-cores/src/main/cores/ontology/conf/schema.xml
@@ -35,7 +35,6 @@
     <field name="aspect" type="string" indexed="true" stored="true"/>
     <field name="usage" type="string" indexed="false" stored="true"/>
     <field name="subset" type="string" indexed="false" stored="true" multiValued="true"/>
-    <field name="children" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="synonym" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="synonymName" type="text_ignorecase" indexed="true" stored="false" multiValued="true"/>
 


### PR DESCRIPTION
Refactor the way the children are loaded into the ontology term. We now use the ontology graph for this.

Add information  on the relationship the child term ids have with the parent.