### PR TITLE
GOA-2135_Redirect_secondary_terms

### DIFF
--- a/ontology-common/src/main/java/uk/ac/ebi/quickgo/ontology/common/OntologyRepository.java
+++ b/ontology-common/src/main/java/uk/ac/ebi/quickgo/ontology/common/OntologyRepository.java
@@ -19,7 +19,8 @@ import org.springframework.data.solr.repository.SolrCrudRepository;
  * @author Edd
  */
 public interface OntologyRepository extends SolrCrudRepository<OntologyDocument, String> {
-    String QUERY_ONTOLOGY_TYPE_AND_ID = OntologyFields.ONTOLOGY_TYPE + ":?0 AND " + OntologyFields.ID + ":(?1)";
+    String QUERY_ONTOLOGY_TYPE_AND_ID = OntologyFields.ONTOLOGY_TYPE + ":?0 " +
+            "AND (" + OntologyFields.ID + ":(?1) OR " + OntologyFields.SECONDARY_ID + ":(?1))";
 
     // complete
     @Query(QUERY_ONTOLOGY_TYPE_AND_ID) List<OntologyDocument> findCompleteByTermId(String idType, List<String> ids);

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/ECOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/ECOControllerIT.java
@@ -20,6 +20,10 @@ public class ECOControllerIT extends OBOControllerIT {
     private static final String ECO_0000001 = "ECO:0000001";
     private static final String ECO_0000002 = "ECO:0000002";
 
+    @Override protected OntologyDocument createBasicDoc(String id, String name) {
+        return OntologyDocMocker.createECODoc(id, name);
+    }
+
     @Override
     protected List<OntologyDocument> createBasicDocs() {
         return Arrays.asList(
@@ -33,7 +37,8 @@ public class ECOControllerIT extends OBOControllerIT {
                 (Collectors.toList());
     }
 
-    private String createId(int idNum) {
+    @Override
+    protected String createId(int idNum) {
         return String.format("ECO:%07d", idNum);
     }
 

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
@@ -67,13 +67,18 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(jsonPath("$.usage").value("Unrestricted"));
     }
 
+    @Override protected OntologyDocument createBasicDoc(String id, String name) {
+        return OntologyDocMocker.createGODoc(id, name);
+    }
+
     @Override protected List<OntologyDocument> createNDocs(int n) {
         return IntStream.range(1, n + 1)
                 .mapToObj(i -> OntologyDocMocker.createGODoc(createId(i), "go doc name " + i)).collect
                         (Collectors.toList());
     }
 
-    private String createId(int idNum) {
+    @Override
+    protected String createId(int idNum) {
         return String.format("GO:%07d", idNum);
     }
 

--- a/solr-cores/src/main/cores/ontology/conf/schema.xml
+++ b/solr-cores/src/main/cores/ontology/conf/schema.xml
@@ -25,7 +25,7 @@
     <field name="id_join" type="string" indexed="true" stored="false"/>
     <field name="ontologyType" type="string" indexed="true" stored="true"/>
     <field name="name" type="text_ignorecase" indexed="true" stored="true"/>
-    <field name="secondaryId" type="string" indexed="false" stored="true" multiValued="true"/>
+    <field name="secondaryId" type="lowercase" indexed="true" stored="true" multiValued="true"/>
     <field name="isObsolete" type="boolean" indexed="false" stored="true"/>
     <field name="replacements" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="replaces" type="string" indexed="false" stored="true" multiValued="true"/>


### PR DESCRIPTION
Allows a client to lookup a GO or ECO term by using its secondary identifier.