### PR TITLE
Goa 2273 filter annotations by target set

### DIFF
--- a/annotation-common/src/main/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocument.java
+++ b/annotation-common/src/main/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocument.java
@@ -59,7 +59,7 @@ public class AnnotationDocument implements QuickGODocument {
     public List<String> extensions;
 
     @Field(AnnotationFields.TARGET_SET)
-    public List<String> targetSets;
+    public List<String> targetSet;
 
     @Override public String getUniqueName() {
         return id;

--- a/annotation-common/src/main/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationFields.java
+++ b/annotation-common/src/main/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationFields.java
@@ -30,6 +30,7 @@ public class AnnotationFields {
     public static final String GENE_PRODUCT_TYPE = "geneProductType";
     public static final String DB_SUBSET = "dbSubset";
     public static final String TAXON_ID = "taxonId";
+    public static final String TARGET_SET = "targetSet";
 
     /**
      * Annotation fields that are stored, and can therefore be retrieved.
@@ -62,6 +63,7 @@ public class AnnotationFields {
         public static final String GO_ID = storeAndGet(VALUES, AnnotationFields.GO_ID);
         public static final String GENEPRODUCT_ID = storeAndGet(VALUES, AnnotationFields.GENE_PRODUCT_ID);
         public static final String GENE_PRODUCT_TYPE = storeAndGet(VALUES, AnnotationFields.GENE_PRODUCT_TYPE);
+        public static final String TARGET_SET = storeAndGet(VALUES, AnnotationFields.TARGET_SET);
 
         public static boolean isSearchable(String field) {
             return VALUES.contains(field);

--- a/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocMocker.java
+++ b/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocMocker.java
@@ -24,8 +24,8 @@ public class AnnotationDocMocker {
             "results_in_development_of(UBERON:0006000)");
     public static final String OBJECT_SYMBOL = "moeA5";
     public static final String OBJECT_TYPE = "protein";
-    public static final String SUB_SET = "KRUK";
     public static final int TAXON_ID = 12345;
+    public static final List<String> TARGET_SET = Arrays.asList("KRUK","BHF-UCL","Exosome");
 
 
 
@@ -51,8 +51,8 @@ public class AnnotationDocMocker {
         doc.extensions = EXTENSIONS;
         doc.dbObjectSymbol = OBJECT_SYMBOL;
         doc.geneProductType = OBJECT_TYPE;
-        doc.dbSubset = SUB_SET;
         doc.taxonId = TAXON_ID;
+        doc.targetSet = TARGET_SET;
 
         return doc;
     }

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
@@ -33,8 +33,7 @@ public class AnnotationRequest {
     static final String USAGE_RELATIONSHIPS = "usageRelationships";
     private static final String ASPECT_FIELD = "aspect";
     private static final String[] TARGET_FIELDS = new String[]{ASPECT_FIELD, ASSIGNED_BY, TAXON_ID, GO_EVIDENCE,
-            QUALIFIER, REFERENCE_SEARCH, WITH_FROM_SEARCH, ECO_ID, GENE_PRODUCT_ID, GO_ID, GENE_PRODUCT_TYPE, DB_SUBSET};
-            QUALIFIER, REFERENCE_SEARCH, WITH_FROM_SEARCH, ECO_ID, GENE_PRODUCT_ID, GO_ID, GENE_PRODUCT_TYPE,
+            QUALIFIER, REFERENCE_SEARCH, WITH_FROM_SEARCH, ECO_ID, GENE_PRODUCT_ID, GO_ID, GENE_PRODUCT_TYPE, DB_SUBSET,
             TARGET_SET};
 
     private static final int DEFAULT_PAGE_NUMBER = 1;
@@ -240,8 +239,8 @@ public class AnnotationRequest {
      * Filter by Target Sets e.g. BHF-UCK, KRUK, Parkinsons etc
      * @return
      */
-    public void setTargetSet(String targetSets){
-        filterMap.put(TARGET_SET, targetSets.toLowerCase());
+    public void setTargetSet(String targetSet){
+        filterMap.put(TARGET_SET, targetSet);
     }
 
     public String getTargetSet(){

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
@@ -33,7 +33,8 @@ public class AnnotationRequest {
     static final String USAGE_RELATIONSHIPS = "usageRelationships";
     private static final String ASPECT_FIELD = "aspect";
     private static final String[] TARGET_FIELDS = new String[]{ASPECT_FIELD, ASSIGNED_BY, TAXON_ID, GO_EVIDENCE,
-            QUALIFIER, REFERENCE_SEARCH, WITH_FROM_SEARCH, ECO_ID, GENE_PRODUCT_ID, GO_ID, GENE_PRODUCT_TYPE};
+            QUALIFIER, REFERENCE_SEARCH, WITH_FROM_SEARCH, ECO_ID, GENE_PRODUCT_ID, GO_ID, GENE_PRODUCT_TYPE,
+            TARGET_SET};
 
     private static final int DEFAULT_PAGE_NUMBER = 1;
     private static final String COMMA = ",";
@@ -234,6 +235,17 @@ public class AnnotationRequest {
         return filterMap.get(GENE_PRODUCT_TYPE);
     }
 
+    /**
+     * Filter by Target Sets e.g. BHF-UCK, KRUK, Parkinsons etc
+     * @return
+     */
+    public void setTargetSet(String targetSets){
+        filterMap.put(TARGET_SET, targetSets.toLowerCase());
+    }
+
+    public String getTargetSet(){
+        return filterMap.get(TARGET_SET);
+    }
 
     public int getLimit() {
         return limit;

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -7,6 +7,7 @@ import uk.ac.ebi.quickgo.annotation.common.document.AnnotationDocument;
 import uk.ac.ebi.quickgo.annotation.service.search.SearchServiceConfig;
 import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -1041,6 +1042,40 @@ public class AnnotationControllerIT {
                 .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
                 .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS));
     }
+
+    @Test
+    public void filterByNewTargetSetValueReturnsMatchingDocuments() throws Exception {
+
+        AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
+        doc.targetSet = Arrays.asList("Parkinsons");
+        repository.save(doc);
+
+        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM, "Parkinsons"));
+
+        response.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(contentTypeToBeJson())
+                .andExpect(totalNumOfResults(1))
+                .andExpect(fieldsInAllResultsExist(1));
+    }
+
+
+    @Test
+    public void filterByTargetSetCaseInsensitiveReturnsMatchingDocuments() throws Exception {
+
+        AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
+        doc.targetSet = Arrays.asList("parkinsons");
+        repository.save(doc);
+
+        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM, "PARKINSONS"));
+
+        response.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(contentTypeToBeJson())
+                .andExpect(totalNumOfResults(1))
+                .andExpect(fieldsInAllResultsExist(1));
+    }
+
 
 
     @Test

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -61,6 +61,7 @@ public class AnnotationControllerIT {
     private static final String GO_ID_PARAM = "goId";
     private static final String WITHFROM_PARAM = "withFrom";
     private static final String GENE_PRODUCT_TYPE_PARAM = "gpType";
+    private static final String TARGET_SET_PARAM = "targetSet";
 
     //Test Data
     private static final String NOTEXISTS_ASSIGNED_BY = "ZZZZZ";
@@ -965,6 +966,31 @@ public class AnnotationControllerIT {
         repository.save(doc);
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(GENE_PRODUCT_TYPE_PARAM, "rna"));
+
+        response.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(contentTypeToBeJson())
+                .andExpect(totalNumOfResults(0));
+    }
+
+    //----- Target Sets
+
+    @Test
+    public void filterByTargetSetReturnsMatchingDocuments() throws Exception {
+
+        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM, "KRUK"));
+
+        response.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(contentTypeToBeJson())
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS));
+    }
+
+    @Test
+    public void filterByNonExistentTargetSetReturnsNoDocuments() throws Exception {
+
+        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM, "CLAP"));
 
         response.andDo(print())
                 .andExpect(status().isOk())

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -1017,6 +1017,32 @@ public class AnnotationControllerIT {
                 .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS));
     }
 
+
+    @Test
+    public void filterByAlternateTargetSetReturnsMatchingDocuments() throws Exception {
+
+        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM, "BHF-UCL"));
+
+        response.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(contentTypeToBeJson())
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS));
+    }
+
+    @Test
+    public void filterByTwoTargetSetValuesReturnsMatchingDocuments() throws Exception {
+
+        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM, "KRUK,BHF-UCL"));
+
+        response.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(contentTypeToBeJson())
+                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
+                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS));
+    }
+
+
     @Test
     public void filterByNonExistentTargetSetReturnsNoDocuments() throws Exception {
 
@@ -1028,69 +1054,6 @@ public class AnnotationControllerIT {
                 .andExpect(totalNumOfResults(0));
     }
 
-    //----- Create Test Data ---------------------//
-    //----- Gene Product Subset ---------------------//
-
-    @Test
-    public void filterBySingleGeneProductSubsetReturnsDocuments() throws Exception {
-
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(GP_SUBSET_PARAM,
-                AnnotationDocMocker.SUB_SET));
-
-        response.andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS));
-    }
-
-
-    @Test
-    public void filterByMultipleGeneProductSubsetReturnsDocuments() throws Exception {
-
-        AnnotationDocument docA = AnnotationDocMocker.createAnnotationDoc("A0A123");
-        docA.dbSubset = "BHF-UCL";
-        repository.save(docA);
-
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(GP_SUBSET_PARAM,
-                toCSV(AnnotationDocMocker.SUB_SET, docA.dbSubset)));
-
-        response.andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 1))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 1));
-    }
-
-
-    @Test
-    public void filterByMultipleGeneProductSubsetInMultipleParametersReturnsDocuments() throws Exception {
-
-        AnnotationDocument docA = AnnotationDocMocker.createAnnotationDoc("A0A123");
-        docA.dbSubset = "BHF-UCL";
-        repository.save(docA);
-
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(GP_SUBSET_PARAM,
-                AnnotationDocMocker.SUB_SET).param(GP_SUBSET_PARAM, docA.dbSubset));
-
-        response.andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS + 1))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS + 1));
-    }
-
-
-    @Test
-    public void filterByUnavailableGeneProductSubsetReturnsZeroDocuments() throws Exception {
-
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(GP_SUBSET_PARAM, "AAA"));
-
-        response.andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(0));
-    }
 
     //----- Setup data ---------------------//
 

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -7,7 +7,7 @@ import uk.ac.ebi.quickgo.annotation.common.document.AnnotationDocument;
 import uk.ac.ebi.quickgo.annotation.service.search.SearchServiceConfig;
 import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -32,7 +32,6 @@ import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationFields.*;
 import static uk.ac.ebi.quickgo.annotation.controller.ResponseVerifier.*;
 import static uk.ac.ebi.quickgo.annotation.controller.ResponseVerifier.QUALIFIER;
 import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.DEFAULT_ENTRIES_PER_PAGE;
-import static uk.ac.ebi.quickgo.common.converter.HelpfulConverter.toCSV;
 
 /**
  * RESTful end point for Annotations
@@ -1018,19 +1017,6 @@ public class AnnotationControllerIT {
                 .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS));
     }
 
-
-    @Test
-    public void filterByAlternateTargetSetReturnsMatchingDocuments() throws Exception {
-
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM, "BHF-UCL"));
-
-        response.andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(NUMBER_OF_GENERIC_DOCS))
-                .andExpect(fieldsInAllResultsExist(NUMBER_OF_GENERIC_DOCS));
-    }
-
     @Test
     public void filterByTwoTargetSetValuesReturnsMatchingDocuments() throws Exception {
 
@@ -1047,7 +1033,7 @@ public class AnnotationControllerIT {
     public void filterByNewTargetSetValueReturnsMatchingDocuments() throws Exception {
 
         AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
-        doc.targetSet = Arrays.asList("Parkinsons");
+        doc.targetSet = Collections.singletonList("Parkinsons");
         repository.save(doc);
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM, "Parkinsons"));
@@ -1059,12 +1045,11 @@ public class AnnotationControllerIT {
                 .andExpect(fieldsInAllResultsExist(1));
     }
 
-
     @Test
     public void filterByTargetSetCaseInsensitiveReturnsMatchingDocuments() throws Exception {
 
         AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
-        doc.targetSet = Arrays.asList("parkinsons");
+        doc.targetSet = Collections.singletonList("parkinsons");
         repository.save(doc);
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM, "PARKINSONS"));
@@ -1076,8 +1061,6 @@ public class AnnotationControllerIT {
                 .andExpect(fieldsInAllResultsExist(1));
     }
 
-
-
     @Test
     public void filterByNonExistentTargetSetReturnsNoDocuments() throws Exception {
 
@@ -1088,7 +1071,6 @@ public class AnnotationControllerIT {
                 .andExpect(contentTypeToBeJson())
                 .andExpect(totalNumOfResults(0));
     }
-
 
     //----- Setup data ---------------------//
 

--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/AnnotationDocumentConverter.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/AnnotationDocumentConverter.java
@@ -55,7 +55,7 @@ public class AnnotationDocumentConverter implements ItemProcessor<Annotation, An
         doc.dbObjectSymbol = propertiesMap.get(DB_OBJECT_SYMBOL);
         doc.geneProductType = propertiesMap.get(DB_OBJECT_TYPE);
         doc.taxonId = extractTaxonId(propertiesMap.get(TAXON_ID));
-        doc.targetSets = constructTargetSets(propertiesMap.get(TARGET_SET));
+        doc.targetSet = constructTargetSets(propertiesMap.get(TARGET_SET));
 
         return doc;
     }

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationMocker.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationMocker.java
@@ -22,8 +22,6 @@ class AnnotationMocker {
         annotation.assignedBy = "IntAct";
         annotation.annotationExtension = "occurs_in(CL:1000428)";
         annotation.annotationProperties = "go_evidence=IEA|taxon_id=35758|db_subset=TrEMBL|db_object_symbol=moeA5|db_object_type=protein|db_object_type=protein|target_set=BHF-UCL,Exosome,KRUK";
-        annotation.annotationProperties = "go_evidence=IEA|taxon_id=35758|db_subset=TrEMBL|db_object_symbol=moeA5|db_object_type=protein|target_set=BHF-UCL,Exosome,KRUK";
-
         return annotation;
     }
 }

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationMocker.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationMocker.java
@@ -21,7 +21,7 @@ class AnnotationMocker {
         annotation.with = "GO:0036376,GO:1990573";
         annotation.assignedBy = "IntAct";
         annotation.annotationExtension = "occurs_in(CL:1000428)";
-        annotation.annotationProperties = "go_evidence=IEA|taxon_id=35758|db_subset=TrEMBL|db_object_symbol=moeA5|db_object_type=protein";
+        annotation.annotationProperties = "go_evidence=IEA|taxon_id=35758|db_subset=TrEMBL|db_object_symbol=moeA5|db_object_type=protein|target_set=BHF-UCL,Exosome,KRUK";
 
         return annotation;
     }


### PR DESCRIPTION
A set of gene products can be defined for a project. This set is the gene products the project is interested in annotating.
QuickGO must allow annotations to be filtered by the gene products sets defined (aka target sets)