### PR TITLE
GOA-2306_taxon_id_is_0

### DIFF
--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/Annotation.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/Annotation.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.quickgo.annotation.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 
 /**
@@ -33,6 +34,11 @@ public class Annotation {
     public String assignedBy;
 
     public List<String> extensions;
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public int getTaxonId() {
+        return taxonId;
+    }
 
     @Override public boolean equals(Object o) {
         if (this == o) {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -220,7 +220,8 @@ public class AnnotationControllerIT {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(TAXON_ID_PARAM, Integer.toString(taxonId)));
 
-        response.andDo(print()).andExpect(status().isOk())
+        response.andDo(print())
+                .andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
                 .andExpect(totalNumOfResults(1))
                 .andExpect(fieldsInAllResultsExist(1))

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/ResponseVerifier.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/ResponseVerifier.java
@@ -43,6 +43,14 @@ final class ResponseVerifier {
         return jsonPath(RESULTS + ".*." + fieldName, contains(values));
     }
 
+    static ResultMatcher valuesOccursInField(String fieldName, Integer... values) {
+        return jsonPath(RESULTS + ".*." + fieldName, contains(values));
+    }
+
+    static ResultMatcher fieldDoesNotExist(String fieldName) {
+        return jsonPath(RESULTS + ".*." + fieldName).doesNotExist();
+    }
+
     static ResultMatcher atLeastOneResultHasItem(String fieldName, String value) {
         return jsonPath(RESULTS + ".*." + fieldName, hasItem(value));
     }

--- a/solr-cores/src/main/cores/annotation/conf/schema.xml
+++ b/solr-cores/src/main/cores/annotation/conf/schema.xml
@@ -84,7 +84,7 @@
     <field name="qualifier" type="string" indexed="true" stored="true" multiValued="false"/>
     <field name="reference" type="string" indexed="true" stored="true" multiValued="false"/>
     <field name="targetSet" type="text_ignorecase" indexed="true" stored="false" multiValued="true"/>
-    <field name="taxonId" type="int" indexed="true" stored="false" multiValued="false"/>
+    <field name="taxonId" type="int" indexed="true" stored="true" multiValued="false"/>
     <field name="withFrom" type="string" indexed="false" stored="true" multiValued="true"/>
 
     <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->

--- a/solr-cores/src/main/cores/annotation/conf/schema.xml
+++ b/solr-cores/src/main/cores/annotation/conf/schema.xml
@@ -81,7 +81,7 @@
     <field name="referenceSearch" type="reference_ignorecase" indexed="true" stored="false" multiValued="false"/>
     <field name="withFrom" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="withFromSearch" type="database_ignorecase" indexed="true" stored="false" multiValued="true"/>
-    <field name="taxonId" type="int" indexed="true" stored="false" multiValued="false"/>
+    <field name="taxonId" type="int" indexed="true" stored="true" multiValued="false"/>
     <field name="interactingTaxonId" type="int" indexed="false" stored="true" multiValued="false"/>
     <field name="assignedBy" type="string" indexed="true" stored="true" multiValued="false"/>
     <field name="extension" type="string" indexed="false" stored="true" multiValued="true"/>


### PR DESCRIPTION
  * schema.xml needed taxonId to be stored
  * relevant tests updated to check contents of response
  * added test to ensure if taxonId is 0, then nothing is returned, because 0 means invalid taxonId internally (e.g., if source datafile didn't contain it)