### PR TITLE
GOA-2002: Filter annotation by EXACT ontology usage

### DIFF
--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
@@ -222,7 +222,7 @@ public class AnnotationRequest {
         return filterMap.get(EVIDENCE_CODE);
     }
 
-    @Pattern(regexp = "^exact|slim|descendants$", flags = CASE_INSENSITIVE, message = "Invalid usage: " +
+    @Pattern(regexp = "^slim|descendants$", flags = CASE_INSENSITIVE, message = "Invalid usage: " +
             "${validatedValue})")
     public String getUsage() {
         return filterMap.get(USAGE_FIELD);

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
@@ -476,14 +476,33 @@ public class AnnotationRequestValidationIT {
         assertThat(validator.validate(annotationRequest), hasSize(greaterThan(0)));
     }
 
-    // descendant parameters
+    // usage parameters
     @Test
-    public void usageValueIsValid() {
-        String usage = "exact";
+    public void descendantsUsageIsValid() {
+        String usage = "descendants";
 
         annotationRequest.setUsage(usage);
 
         assertThat(validator.validate(annotationRequest), hasSize(0));
+    }
+
+    @Test
+    public void slimUsageIsValid() {
+        String usage = "slim";
+
+        annotationRequest.setUsage(usage);
+
+        assertThat(validator.validate(annotationRequest), hasSize(0));
+    }
+
+    @Test
+    public void exactUsageIsValid() {
+        // rather than specifying exact, user should just filter by GO Id.
+        String usage = "exact";
+
+        annotationRequest.setUsage(usage);
+
+        assertThat(validator.validate(annotationRequest), hasSize(greaterThan(0)));
     }
 
     @Test


### PR DESCRIPTION
The functionality of this is covered by the already existing filtering by GO id capabilities for annotation. Therefore, this branch just removes the 'exact' option for filtering by usage.