### PR TITLE
GOA-2422 filtering by gene product set (goal)

### DIFF
--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -1096,11 +1096,12 @@ public class AnnotationControllerIT {
     @Test
     public void filterByTargetSetContainingSpacesReturnsMatchingDocuments() throws Exception {
         AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
-        doc.targetSets = Collections.singletonList("Reference Genome");
+        String targetSetWithSpaces = "Reference Genome";
+        doc.targetSets = Collections.singletonList(targetSetWithSpaces);
         repository.save(doc);
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(),
-                "Reference Genome"));
+                targetSetWithSpaces));
 
         response.andDo(print())
                 .andExpect(status().isOk())

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -612,7 +612,8 @@ public class AnnotationControllerIT {
 
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(EVIDENCE_CODE_PARAM.getName(), AnnotationDocMocker.ECO_ID)
-                        .param(EVIDENCE_CODE_PARAM.getName(), doc.evidenceCode).param(EVIDENCE_CODE_PARAM.getName(), MISSING_ECO_ID));
+                        .param(EVIDENCE_CODE_PARAM.getName(), doc.evidenceCode)
+                        .param(EVIDENCE_CODE_PARAM.getName(), MISSING_ECO_ID));
 
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
@@ -730,7 +731,8 @@ public class AnnotationControllerIT {
 
     @Test
     public void searchingForUnknownWithFromBringsBackNoResults() throws Exception {
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM.getName(), "XXX:54321"));
+        ResultActions response =
+                mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM.getName(), "XXX:54321"));
 
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
@@ -739,7 +741,8 @@ public class AnnotationControllerIT {
 
     @Test
     public void successfulLookupWithFromUsingDatabaseNameOnly() throws Exception {
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM.getName(), "InterPro"));
+        ResultActions response =
+                mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM.getName(), "InterPro"));
 
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
@@ -751,7 +754,8 @@ public class AnnotationControllerIT {
 
     @Test
     public void successfulLookupWithFromUsingDatabaseIdOnly() throws Exception {
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM.getName(), "IPR015421"));
+        ResultActions response =
+                mockMvc.perform(get(RESOURCE_URL + "/search").param(WITHFROM_PARAM.getName(), "IPR015421"));
 
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
@@ -827,7 +831,8 @@ public class AnnotationControllerIT {
         AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
         doc.reference = "PMID:0000002";
         repository.save(doc);
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM.getName(), doc.reference));
+        ResultActions response =
+                mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM.getName(), doc.reference));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -872,7 +877,8 @@ public class AnnotationControllerIT {
         repository.save(docB);
 
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(REF_PARAM.getName(),
-                AnnotationDocMocker.REFERENCE).param(REF_PARAM.getName(), docA.reference).param(REF_PARAM.getName(), docB.reference));
+                AnnotationDocMocker.REFERENCE).param(REF_PARAM.getName(), docA.reference)
+                .param(REF_PARAM.getName(), docB.reference));
 
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
@@ -956,7 +962,6 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterByGeneProductTypeReturnsMatchingDocuments() throws Exception {
-
         ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(GENE_PRODUCT_TYPE_PARAM.getName(),
                 "protein"));
 
@@ -969,12 +974,12 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterBySingleGeneProductTypeOfRnaReturnsMatchingDocument() throws Exception {
-
         AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
         doc.geneProductType = "rna";
         repository.save(doc);
 
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(GENE_PRODUCT_TYPE_PARAM.getName(), "RNA"));
+        ResultActions response =
+                mockMvc.perform(get(RESOURCE_URL + "/search").param(GENE_PRODUCT_TYPE_PARAM.getName(), "RNA"));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -985,7 +990,6 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterAnnotationsByTwoGeneProductTypesAsOneParameterReturnsMatchingDocuments() throws Exception {
-
         AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
         doc.geneProductType = "complex";
         repository.save(doc);
@@ -1002,7 +1006,6 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterAnnotationsByTwoGeneProductTypesAsTwoParametersReturnsMatchingDocuments() throws Exception {
-
         AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
         doc.geneProductType = "complex";
         repository.save(doc);
@@ -1019,12 +1022,12 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterByNonExistentGeneProductTypeReturnsNothing() throws Exception {
-
         AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
         doc.geneProductType = "complex";
         repository.save(doc);
 
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(GENE_PRODUCT_TYPE_PARAM.getName(), "rna"));
+        ResultActions response =
+                mockMvc.perform(get(RESOURCE_URL + "/search").param(GENE_PRODUCT_TYPE_PARAM.getName(), "rna"));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -1036,8 +1039,8 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterByTargetSetReturnsMatchingDocuments() throws Exception {
-
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(), "KRUK"));
+        ResultActions response =
+                mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(), "KRUK"));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -1048,8 +1051,8 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterByTwoTargetSetValuesReturnsMatchingDocuments() throws Exception {
-
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(), "KRUK,BHF-UCL"));
+        ResultActions response =
+                mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(), "KRUK,BHF-UCL"));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -1060,12 +1063,12 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterByNewTargetSetValueReturnsMatchingDocuments() throws Exception {
-
         AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
         doc.targetSets = Collections.singletonList("Parkinsons");
         repository.save(doc);
 
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(), "Parkinsons"));
+        ResultActions response =
+                mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(), "Parkinsons"));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -1076,12 +1079,28 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterByTargetSetCaseInsensitiveReturnsMatchingDocuments() throws Exception {
-
         AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
         doc.targetSets = Collections.singletonList("parkinsons");
         repository.save(doc);
 
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(), "PARKINSONS"));
+        ResultActions response =
+                mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(), "PARKINSONS"));
+
+        response.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(contentTypeToBeJson())
+                .andExpect(totalNumOfResults(1))
+                .andExpect(fieldsInAllResultsExist(1));
+    }
+
+    @Test
+    public void filterByTargetSetContainingSpacesReturnsMatchingDocuments() throws Exception {
+        AnnotationDocument doc = AnnotationDocMocker.createAnnotationDoc("A0A123");
+        doc.targetSets = Collections.singletonList("Reference Genome");
+        repository.save(doc);
+
+        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(),
+                "Reference Genome"));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -1092,8 +1111,8 @@ public class AnnotationControllerIT {
 
     @Test
     public void filterByNonExistentTargetSetReturnsNoDocuments() throws Exception {
-
-        ResultActions response = mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(), "CLAP"));
+        ResultActions response =
+                mockMvc.perform(get(RESOURCE_URL + "/search").param(TARGET_SET_PARAM.getName(), "CLAP"));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -1160,7 +1179,6 @@ public class AnnotationControllerIT {
                 .mapToObj(i -> AnnotationDocMocker.createAnnotationDoc(createGPId(i))).collect
                         (Collectors.toList());
     }
-
 
     private int totalPages(int totalEntries, int resultsPerPage) {
         return (int) Math.ceil(totalEntries / resultsPerPage) + 1;

--- a/annotation-rest/src/test/resources/search.properties
+++ b/annotation-rest/src/test/resources/search.properties
@@ -10,7 +10,7 @@ geneproduct.db.xref.valid.regexes=src/test/resources/DB_XREFS_ENTITIES.dat.gz
 annotation.terms.query.compatible.fields=\
   assignedBy,evidenceCode,goEvidence,goId,\
   geneProductSubset,geneProductType,\
-  qualifier,targetSet,taxonId
+  qualifier,taxonId
 
 ## =============== Validation  =================
 geneproduct.db.xref.valid.casesensitive=false

--- a/deployments/src/main/distros/rest/bin/annotation/application.properties
+++ b/deployments/src/main/distros/rest/bin/annotation/application.properties
@@ -26,4 +26,4 @@ geneproduct.db.xref.valid.casesensitive=false
 annotation.terms.query.compatible.fields=\
   assignedBy,evidenceCode,goEvidence,goId,\
   geneProductSubset,geneProductType,\
-  qualifier,targetSet,taxonId
+  qualifier,taxonId


### PR DESCRIPTION
solution for front end is to use the `targetSet` request parameter rather than `geneProductSubset`. Please note, this is subject to change with ongoing back-end refactoring. However, for now, this is the solution.

`targetSet` field in annotation makes use of a non-straight-forward text analyzer. therefore it is not suitable for use as an terms query, hence removing `targetSet` from terms query compatible fields in `application.properties` files.

This PR includes an additional test to ensure that target sets specified by the front end, which contain spaces, e.g., "Reference Genome" can be searched. Previously, this did not work, because a terms query was being issued.
