### PR TITLE
Goa 2545 fix co terms not being written

### DIFF
--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfig.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfig.java
@@ -46,10 +46,10 @@ public class CoTermsConfig {
             "together", "compared"};
     private static final String DELIMITER = "\t";
 
-    @Value("${indexing.coterms.manual:/nfs/public/rw/goa/quickgo_origin/full/CoTermsManual}")
+    @Value("${indexing.coterms.manual:#{systemProperties['user.dir']}/QuickGO/CoTermsManual}")
     private String manualCoTermsPath;
 
-    @Value("${indexing.coterms.all:/nfs/public/rw/goa/quickgo_origin/full/CoTermsAll}")
+    @Value("${indexing.coterms.all:#{systemProperties['user.dir']}/QuickGO/CoTermsAll}")
     private String allCoTermsPath;
 
     @Bean

--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfig.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfig.java
@@ -49,7 +49,7 @@ public class CoTermsConfig {
     @Value("${indexing.coterms.manual:/nfs/public/rw/goa/quickgo_origin/full/CoTermsManual}")
     private String manualCoTermsPath;
 
-    @Value("${indexing.coterms.manual:/nfs/public/rw/goa/quickgo_origin/full/CoTermsAll}")
+    @Value("${indexing.coterms.all:/nfs/public/rw/goa/quickgo_origin/full/CoTermsAll}")
     private String allCoTermsPath;
 
     @Bean

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingBatchIT.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingBatchIT.java
@@ -93,27 +93,28 @@ public class AnnotationIndexingBatchIT {
         ));
 
         //Manual
-        List<StepExecution> jobsSingleStepCoTermManual = jobExecution.getStepExecutions()
+        List<StepExecution> summarizeCoTermManualSteps = jobExecution.getStepExecutions()
                 .stream()
                 .filter(step -> step.getStepName().equals(CO_TERM_MANUAL_SUMMARIZATION_STEP))
                 .collect(Collectors.toList());
-        assertThat(jobsSingleStepCoTermManual, hasSize(1));
-        StepExecution coTermsManualStep = jobsSingleStepCoTermManual.get(0);
+        assertThat(summarizeCoTermManualSteps, hasSize(1));
+        StepExecution coTermsManualStep = summarizeCoTermManualSteps.get(0);
         assertThat(coTermsManualStep.getReadCount(), is(4));
         assertThat(coTermsManualStep.getReadSkipCount(), is(0));
         assertThat(coTermsManualStep.getProcessSkipCount(), is(0));
         assertThat(coTermsManualStep.getWriteCount(), is(4));
 
-        List<StepExecution> jobsSingleStepCoTermAll = jobExecution.getStepExecutions()
+        List<StepExecution> summarizeCoTermAllSteps = jobExecution.getStepExecutions()
                 .stream()
                 .filter(step -> step.getStepName().equals(CO_TERM_ALL_SUMMARIZATION_STEP))
                 .collect(Collectors.toList());
-        assertThat(jobsSingleStepCoTermAll, hasSize(1));
-        StepExecution coTermsAllStep = jobsSingleStepCoTermAll.get(0);
+        assertThat(summarizeCoTermAllSteps, hasSize(1));
+        StepExecution coTermsAllStep = summarizeCoTermAllSteps.get(0);
         assertThat(coTermsAllStep.getReadCount(), is(5));
         assertThat(coTermsAllStep.getReadSkipCount(), is(0));
         assertThat(coTermsAllStep.getProcessSkipCount(), is(0));
         assertThat(coTermsAllStep.getWriteCount(), is(5));
+        assertThat(coTermsAllStep.getExecutionContext().get("FlatFileItemWriter.written"), is(7L));
 
         //Has finished
         BatchStatus status = jobExecution.getStatus();


### PR DESCRIPTION
A copy and paste error meant the CoTermsAll data was being written to the CoTermsManual file.