### PR TITLE
Goa 2594 increase go term limit

### DIFF
--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
@@ -34,7 +34,7 @@ import static uk.ac.ebi.quickgo.rest.controller.request.ArrayPattern.Flag.CASE_I
  * Created with IntelliJ IDEA.
  */
 public class AnnotationRequest {
-    static final int MAX_GO_IDS = 500;
+    static final int MAX_GO_IDS = 600;
     static final int MAX_GENE_PRODUCT_IDS = 500;
     static final int MAX_EVIDENCE_CODE = 100;
     static final int MAX_TAXON_IDS = 50;

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
@@ -330,6 +330,14 @@ public class AnnotationRequestValidationIT {
     }
 
     @Test
+    public void requestingMaximumNumberOfGOIdentifiersIsValid() {
+        String[] goIds = generateValues(IdGeneratorUtil::createGoId, AnnotationRequest.MAX_GO_IDS);
+        annotationRequest.setGoId(goIds);
+        Set<ConstraintViolation<AnnotationRequest>> violations = validator.validate(annotationRequest);
+        assertThat(violations, hasSize(0));
+    }
+
+    @Test
     public void exceedingMaximumNumberOfGOIdentifiersSendsError() {
         int numIds = AnnotationRequest.MAX_GO_IDS + 1;
 


### PR DESCRIPTION
500->600 for number of GO term ids allowed by the front end.