### PR TITLE
adding retry logic whilst indexing, e.g., when Solrcloud is busy

### DIFF
--- a/annotation-rest/src/test/resources/application.yml
+++ b/annotation-rest/src/test/resources/application.yml
@@ -8,12 +8,12 @@ annotation:
         fields: ['assignedBy', 'evidenceCode', 'goEvidence', 'goId', 'dbSubset', 'geneProductType', 'qualifier',
         'targetSet', 'taxonId', 'geneProductId']
   validation:
-    validationResource: classpath:DB_XREFS_ENTITIES.dat.gz
+    validationResource: DB_XREFS_ENTITIES.dat.gz
     chunk: 30
     headerLines: 1
     reference_dbs: ['pmid', 'doi', 'go_ref', 'reactome']
   download:
-    ontologySource: classpath:ONTOLOGY_IRI.dat.gz
+    ontologySource: ONTOLOGY_IRI.dat.gz
     pageSize: 6
 
 search:

--- a/deployments/src/main/distros/rest/bin/annotation/application.yml
+++ b/deployments/src/main/distros/rest/bin/annotation/application.yml
@@ -51,7 +51,7 @@ annotation:
       keepAliveSeconds: 7200
       allowCoreThreadTimeout: true
       waitForTasksToCompleteOnShutdown: false
-    ontologySource: classpath:ONTOLOGY_IRI.dat.gz
+    ontologySource: ONTOLOGY_IRI.dat.gz
   terms:
       query:
         compatible:

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationDocumentWriteRetryHelper.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationDocumentWriteRetryHelper.java
@@ -1,0 +1,105 @@
+package uk.ac.ebi.quickgo.index.annotation;
+
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.mockito.stubbing.Stubber;
+import org.springframework.batch.item.ItemWriter;
+import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.util.MatcherAssertionErrors.assertThat;
+
+/**
+ * Utility methods to help the testing of the retry logic associated with writing
+ * annotation documents to an index, in the presence of an possibly busy
+ * Solr instance, which may occasionally not be responsive due to other tasks, e.g.,
+ * dedicated to Zookeeper.
+ *
+ * Created by edd on 23/02/2017.
+ */
+public class AnnotationDocumentWriteRetryHelper {
+    private static final String HOST = "http://www.myhost.com";
+    private static final String MESSAGE = "Looks like the host is not reachable?!";
+    private static final int CODE = 1;
+
+    /**
+     * Stubs successive Solrmethod call actions based on a given list of {@link SolrResponse}
+     * values. {@link SolrResponse#OK} simulates that Solr was able to write the documents it
+     * received; {@link SolrResponse#REMOTE_EXCEPTION} simulates Solr being busy and responding
+     * with a {@link HttpSolrClient.RemoteSolrException}, meaning the documents could not be
+     * written
+     * @param responses represents a list of behavioural responses from Solr
+     * @return a {@link Stubber} which can be associated with a method call
+     */
+    static Stubber stubSolrWriteResponses(List<SolrResponse> responses) {
+        Stubber stubber = null;
+        for (SolrResponse response : responses) {
+            switch (response) {
+                case OK:
+                    stubber = (stubber == null) ? doNothing() : stubber.doNothing();
+                    break;
+                case REMOTE_EXCEPTION:
+                    stubber = (stubber == null) ? doThrow(new HttpSolrClient.RemoteSolrException(HOST, CODE, MESSAGE, null))
+                            : stubber.doThrow(new HttpSolrClient.RemoteSolrException(HOST, CODE, MESSAGE, null));
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown SolrResponse");
+            }
+        }
+        return stubber;
+    }
+
+    /**
+     * Validates that the documents sent to be written to Solr, constitute the correct
+     * documents that *should* be written; even when Solr occasionally is not able to write
+     * @param docsSentToBeWritten a list of document lists, each of which was sent as an
+     *                            argument to an {@link ItemWriter}, for writing to Solr.
+     */
+    static void validateWriteAttempts(List<SolrResponse> responses, List<List<AnnotationDocument>> docsSentToBeWritten) {
+        int counter = 0;
+        List<AnnotationDocument> docsToWrite;
+        List<AnnotationDocument> docsToRetryWriting = Collections.emptyList();
+
+        Iterator<SolrResponse> responsesIt = responses.iterator();
+        for(int i = 0; i < docsSentToBeWritten.size() && responsesIt.hasNext(); i++) {
+            SolrResponse response = responsesIt.next();
+
+            docsToWrite = docsSentToBeWritten.get(counter++);
+            switch (response) {
+                case OK:
+                    // documents could not be written last time, but can this time
+                    if (!docsToRetryWriting.isEmpty()) {
+                        assertThat(extractDocAttribute(docsToWrite, d -> d.geneProductId),
+                                is(extractDocAttribute(docsToRetryWriting, d -> d.geneProductId)));
+                        docsToRetryWriting = Collections.emptyList();
+                    }
+                    break;
+                case REMOTE_EXCEPTION:
+                    docsToRetryWriting = docsToWrite;
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown SolrResponse");
+            }
+        }
+    }
+
+    private static <T> List<T> extractDocAttribute(
+            List<AnnotationDocument> docs,
+            Function<AnnotationDocument, T> transformation) {
+        return docs.stream().map(transformation).collect(Collectors.toList());
+    }
+
+    /**
+     * Represents possible responses from Solr -- extend if needed
+     */
+    public enum SolrResponse {
+        OK, REMOTE_EXCEPTION
+    }
+}

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingRetriesSolrWritesWithFailureIT.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingRetriesSolrWritesWithFailureIT.java
@@ -1,0 +1,137 @@
+package uk.ac.ebi.quickgo.index.annotation;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationContextLoader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
+import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.index.annotation.AnnotationDocumentWriteRetryHelper.SolrResponse;
+import uk.ac.ebi.quickgo.index.annotation.coterms.CoTermTemporaryDataStore;
+import uk.ac.ebi.quickgo.index.common.JobTestRunnerConfig;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.util.MatcherAssertionErrors.assertThat;
+import static uk.ac.ebi.quickgo.index.annotation.AnnotationConfig.ANNOTATION_INDEXING_JOB_NAME;
+import static uk.ac.ebi.quickgo.index.annotation.AnnotationConfig.ANNOTATION_INDEXING_STEP_NAME;
+import static uk.ac.ebi.quickgo.index.annotation.AnnotationDocumentWriteRetryHelper.stubSolrWriteResponses;
+import static uk.ac.ebi.quickgo.index.annotation.AnnotationDocumentWriteRetryHelper.validateWriteAttempts;
+
+/**
+ * <p>Tests whether Spring Batch's retry + backoff policy works as expected. This class simulates annotation indexing
+ * encountering two Solr remote host exceptions occurring (e.g., perhaps Solr becomes overloaded during indexing),
+ * subsequently retrying the writes. However, since the maximum number of retries (see application.properties)
+ * is exhausted, retrying eventually fails.
+ *
+ * <p>The mocked behaviour of the "sometimes erroneous" Solr instance has been mocked in {@link RetryConfig}.
+ *
+ * Created 22/04/16
+ * @author Edd
+ */
+@ActiveProfiles(profiles = {"embeddedServer", "tooManySolrRemoteHostErrors"})
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(
+        classes = {AnnotationConfig.class, JobTestRunnerConfig.class, CoTermTemporaryDataStore.Config.class,
+                AnnotationIndexingRetriesSolrWritesWithFailureIT.RetryConfig.class},
+        loader = SpringApplicationContextLoader.class)
+public class AnnotationIndexingRetriesSolrWritesWithFailureIT {
+
+    @ClassRule
+    public static final CoTermTemporaryDataStore coTermsDataStore = new CoTermTemporaryDataStore();
+
+    @ClassRule
+    public static final TemporarySolrDataStore solrDataStore = new TemporarySolrDataStore();
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private ItemWriter<AnnotationDocument> annotationSolrServerWriter;
+
+    @Captor
+    private ArgumentCaptor<List<AnnotationDocument>> argumentCaptor;
+
+    private static final List<AnnotationDocumentWriteRetryHelper.SolrResponse> SOLR_RESPONSES = asList(
+            SolrResponse.OK,                // simulate writing first chunk (size 2: both valid)
+            SolrResponse.REMOTE_EXCEPTION,  // error
+            SolrResponse.OK,                // simulate writing second chunk (size 2: both valid)
+            SolrResponse.OK,                // simulate writing second chunk (size 1: only 1 valid document in chunk)
+            SolrResponse.REMOTE_EXCEPTION,  // error
+            SolrResponse.REMOTE_EXCEPTION,  // too many errors -- indexing fails
+            SolrResponse.OK);               // never called
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void tooManyRetriesAndFailedIndexingJob() throws Exception {
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+        assertThat(jobExecution.getJobInstance().getJobName(), is(ANNOTATION_INDEXING_JOB_NAME));
+
+        List<StepExecution> jobsSingleStepAsList = jobExecution.getStepExecutions()
+                .stream()
+                .filter(step -> step.getStepName().equals(ANNOTATION_INDEXING_STEP_NAME))
+                .collect(Collectors.toList());
+        assertThat(jobsSingleStepAsList, hasSize(1));
+
+        StepExecution indexingStep = jobsSingleStepAsList.get(0);
+
+        assertThat(indexingStep.getReadCount(), is(8));
+        assertThat(indexingStep.getReadSkipCount(), is(0));
+        assertThat(indexingStep.getProcessSkipCount(), is(2));
+        assertThat(indexingStep.getWriteSkipCount(), is(0));
+        assertThat(indexingStep.getWriteCount(), is(5));
+
+        verify(annotationSolrServerWriter, times(6)).write(argumentCaptor.capture());
+        List<List<AnnotationDocument>> docsSentToBeWritten = argumentCaptor.getAllValues();
+        validateWriteAttempts(SOLR_RESPONSES, docsSentToBeWritten);
+
+        BatchStatus status = jobExecution.getStatus();
+        assertThat(status, is(BatchStatus.FAILED));
+    }
+
+    @Profile("tooManySolrRemoteHostErrors")
+    public static class RetryConfig {
+
+        private static final String HOST = "http://www.myhost.com";
+        private static final String MESSAGE = "Looks like the host is not reachable?!";
+        private static final int CODE = 1;
+
+        @Bean
+        @Primary
+        @SuppressWarnings(value = "unchecked")
+        ItemWriter<AnnotationDocument> annotationSolrServerWriter() throws Exception {
+            ItemWriter<AnnotationDocument> mockItemWriter = mock(ItemWriter.class);
+
+            stubSolrWriteResponses(SOLR_RESPONSES)
+                    .when(mockItemWriter).write(any());
+
+            return mockItemWriter;
+        }
+    }
+}

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingRetriesSolrWritesWithSuccessIT.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingRetriesSolrWritesWithSuccessIT.java
@@ -1,0 +1,138 @@
+package uk.ac.ebi.quickgo.index.annotation;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationContextLoader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
+import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.index.annotation.AnnotationDocumentWriteRetryHelper.SolrResponse;
+import uk.ac.ebi.quickgo.index.annotation.coterms.CoTermTemporaryDataStore;
+import uk.ac.ebi.quickgo.index.common.JobTestRunnerConfig;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.util.MatcherAssertionErrors.assertThat;
+import static uk.ac.ebi.quickgo.index.annotation.AnnotationConfig.ANNOTATION_INDEXING_JOB_NAME;
+import static uk.ac.ebi.quickgo.index.annotation.AnnotationConfig.ANNOTATION_INDEXING_STEP_NAME;
+import static uk.ac.ebi.quickgo.index.annotation.AnnotationDocumentWriteRetryHelper.stubSolrWriteResponses;
+import static uk.ac.ebi.quickgo.index.annotation.AnnotationDocumentWriteRetryHelper.validateWriteAttempts;
+
+/**
+ * <p>Tests whether Spring Batch's retry + backoff policy works as expected. This class simulates annotation indexing
+ * encountering two Solr remote host exceptions occurring (e.g., perhaps Solr becomes overloaded during indexing),
+ * subsequently retrying the writes, with success.
+ * <p>
+ * <p>The mocked behaviour of the "sometimes erroneous" Solr instance has been mocked in {@link RetryConfig}.
+ * <p>
+ * Created 22/04/16
+ *
+ * @author Edd
+ */
+@ActiveProfiles(profiles = {"embeddedServer", "twoSolrRemoteHostErrors"})
+//@ActiveProfiles(profiles = {"embeddedServer"})
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(
+        classes = {AnnotationConfig.class, JobTestRunnerConfig.class, CoTermTemporaryDataStore.Config.class,
+                AnnotationIndexingRetriesSolrWritesWithSuccessIT.RetryConfig.class},
+        loader = SpringApplicationContextLoader.class)
+public class AnnotationIndexingRetriesSolrWritesWithSuccessIT {
+
+    @ClassRule
+    public static final CoTermTemporaryDataStore coTermsDataStore = new CoTermTemporaryDataStore();
+
+    @ClassRule
+    public static final TemporarySolrDataStore solrDataStore = new TemporarySolrDataStore();
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private ItemWriter<AnnotationDocument> annotationSolrServerWriter;
+
+    @Captor
+    private ArgumentCaptor<List<AnnotationDocument>> argumentCaptor;
+
+    private static final List<SolrResponse> SOLR_RESPONSES = asList(
+            SolrResponse.OK,                // simulate writing first chunk (size 2: both valid)
+            SolrResponse.REMOTE_EXCEPTION,  // error
+            SolrResponse.OK,                // simulate writing second chunk (size 2: both valid)
+            SolrResponse.REMOTE_EXCEPTION,  // error
+            SolrResponse.OK,                // simulate writing third chunk (size 1: only 1 valid document in chunk)
+            SolrResponse.OK,                // simulate writing fourth chunk (size 1: only 1 valid document in chunk)
+            SolrResponse.OK);               // never called
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void twoRetriesAndSuccessfulIndexingJob() throws Exception {
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+        assertThat(jobExecution.getJobInstance().getJobName(), is(ANNOTATION_INDEXING_JOB_NAME));
+
+        List<StepExecution> jobsSingleStepAsList = jobExecution.getStepExecutions()
+                .stream()
+                .filter(step -> step.getStepName().equals(ANNOTATION_INDEXING_STEP_NAME))
+                .collect(Collectors.toList());
+        assertThat(jobsSingleStepAsList, hasSize(1));
+
+        StepExecution indexingStep = jobsSingleStepAsList.get(0);
+
+        assertThat(indexingStep.getReadCount(), is(8));
+        assertThat(indexingStep.getReadSkipCount(), is(0));
+        assertThat(indexingStep.getProcessSkipCount(), is(2));
+        assertThat(indexingStep.getWriteSkipCount(), is(0));
+
+        assertThat(indexingStep.getWriteCount(), is(6));
+
+        verify(annotationSolrServerWriter, times(6)).write(argumentCaptor.capture());
+        List<List<AnnotationDocument>> docsSentToBeWritten = argumentCaptor.getAllValues();
+        validateWriteAttempts(SOLR_RESPONSES, docsSentToBeWritten);
+
+        BatchStatus status = jobExecution.getStatus();
+        assertThat(status, is(BatchStatus.COMPLETED));
+    }
+
+
+    @Profile("twoSolrRemoteHostErrors")
+    @Configuration
+    public static class RetryConfig {
+
+        @Bean
+        @Primary
+        @SuppressWarnings(value = "unchecked")
+        ItemWriter<AnnotationDocument> annotationSolrServerWriter() throws Exception {
+            ItemWriter<AnnotationDocument> mockItemWriter = mock(ItemWriter.class);
+
+            stubSolrWriteResponses(SOLR_RESPONSES)
+                    .when(mockItemWriter).write(any());
+
+            return mockItemWriter;
+        }
+    }
+}

--- a/indexing/src/test/resources/application.properties
+++ b/indexing/src/test/resources/application.properties
@@ -22,6 +22,9 @@ indexing.annotation.source=goa_uniprot.gpa
 indexing.annotation.chunk.size=2
 indexing.annotation.header.lines=21
 indexing.annotation.skip.limit=100
+indexing.annotation.retries.initialInterval=1000
+indexing.annotation.retries.maxInterval=2000
+indexing.annotation.retries.retryLimit=2
 
 ## ================= Co Terms Indexing =================
 indexing.coterm.loginterval=1000


### PR DESCRIPTION
This uses Spring Batch's retry + backoff policy api.

Given a state where Sorlcloud is busy during indexing (e.g,. perhaps performing some Zookeeper maintenance), the idea is the following:

* sending a "chunk" of documents to be indexed finds that Solrcloud is busy, and the indexing application hits a `RemoteSolrException`
* wait for a configurable period of time, before resending the same chunk of documents (e.g., to give Solrcloud some maintenance time)
* if the subsequent retry fails, continue retrying a configurable number of times.
   * if all retries fail, then indexing can fail (e.g., indicating there is something wrong with Solrcloud)
* if retrying a request succeeds, great.

