### PR TITLE
Goa 2457 configurable co term test

### DIFF
--- a/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/AnnotationRepositoryIT.java
+++ b/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/AnnotationRepositoryIT.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.quickgo.annotation.common;
 
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 
 import org.junit.Before;
 import org.junit.ClassRule;

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AbstractFilterAnnotationByOntologyRESTIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AbstractFilterAnnotationByOntologyRESTIT.java
@@ -4,7 +4,7 @@ import uk.ac.ebi.quickgo.annotation.AnnotationREST;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationRepository;
 import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.ConvertedOntologyFilter;
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 import uk.ac.ebi.quickgo.ontology.common.OntologyRepoConfig;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerDownloadIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerDownloadIT.java
@@ -7,7 +7,7 @@ import uk.ac.ebi.quickgo.annotation.common.AnnotationRepository;
 import uk.ac.ebi.quickgo.annotation.common.document.AnnotationDocMocker;
 import uk.ac.ebi.quickgo.annotation.download.http.GAFHttpMessageConverter;
 import uk.ac.ebi.quickgo.annotation.download.http.GPADHttpMessageConverter;
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -4,7 +4,7 @@ import uk.ac.ebi.quickgo.annotation.AnnotationREST;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationRepository;
 import uk.ac.ebi.quickgo.annotation.common.document.AnnotationDocMocker;
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 
 import java.time.LocalDate;
 import java.time.ZoneId;

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
@@ -5,7 +5,7 @@ import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationRepository;
 import uk.ac.ebi.quickgo.annotation.common.document.AnnotationDocMocker;
 import uk.ac.ebi.quickgo.common.QuickGODocument;
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/common/src/test/java/uk/ac/ebi/quickgo/common/store/BasicTemporaryFolder.java
+++ b/common/src/test/java/uk/ac/ebi/quickgo/common/store/BasicTemporaryFolder.java
@@ -1,0 +1,37 @@
+package uk.ac.ebi.quickgo.common.store;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.ClassRule;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Creates a temporary storage folder which is deleted on exit. Use this class with
+ * the annotation, @ClassRule in tests requiring a temporary data store.
+ *
+ * Note: the purpose of this class is to more robustly guarantee automatic cleanup of
+ * a temporary folder. It has been noted that deleting a {@link TemporaryFolder} explicitly
+ * in an @AfterClass/@After test method, does not reliably delete the folder.
+ *
+ * Created 02/03/17
+ * @author Edd
+ */
+public class BasicTemporaryFolder extends ExternalResource {
+    @ClassRule
+    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    public File getRoot() {
+        return temporaryFolder.getRoot();
+    }
+
+    @Override
+    public void before() throws IOException {
+        temporaryFolder.create();
+    }
+
+    @Override
+    public void after() {
+        temporaryFolder.delete();
+    }
+}

--- a/common/src/test/java/uk/ac/ebi/quickgo/common/store/TemporarySolrDataStore.java
+++ b/common/src/test/java/uk/ac/ebi/quickgo/common/store/TemporarySolrDataStore.java
@@ -1,4 +1,4 @@
-package uk.ac.ebi.quickgo.common.solr;
+package uk.ac.ebi.quickgo.common.store;
 
 import java.io.File;
 import java.io.IOException;

--- a/deployments/src/main/distros/solr/index/bin/annotation/application.properties
+++ b/deployments/src/main/distros/solr/index/bin/annotation/application.properties
@@ -11,4 +11,4 @@ indexing.annotation.skip.limit=100
 indexing.coterms.manual=/nfs/public/rw/goa/quickgo_origin/full/CoTermsManual
 indexing.coterms.all=/nfs/public/rw/goa/quickgo_origin/full/CoTermsAll
 indexing.coterm.loginterval=1000
-indexing.coterms.chunk.size=1
+indexing.coterms.chunkSize=1

--- a/geneproduct-common/src/test/java/uk/ac/ebi/quickgo/geneproduct/common/GeneProductRepositoryIT.java
+++ b/geneproduct-common/src/test/java/uk/ac/ebi/quickgo/geneproduct/common/GeneProductRepositoryIT.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.quickgo.geneproduct.common;
 
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/geneproduct-rest/src/test/java/uk/ac/ebi/quickgo/geneproduct/controller/GeneProductControllerIT.java
+++ b/geneproduct-rest/src/test/java/uk/ac/ebi/quickgo/geneproduct/controller/GeneProductControllerIT.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.quickgo.geneproduct.controller;
 
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 import uk.ac.ebi.quickgo.geneproduct.GeneProductREST;
 import uk.ac.ebi.quickgo.geneproduct.common.GeneProductDocument;
 import uk.ac.ebi.quickgo.geneproduct.common.GeneProductRepository;

--- a/geneproduct-rest/src/test/java/uk/ac/ebi/quickgo/geneproduct/search/GeneProductUserQueryScoringIT.java
+++ b/geneproduct-rest/src/test/java/uk/ac/ebi/quickgo/geneproduct/search/GeneProductUserQueryScoringIT.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.quickgo.geneproduct.search;
 
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 import uk.ac.ebi.quickgo.geneproduct.GeneProductREST;
 import uk.ac.ebi.quickgo.geneproduct.common.GeneProductDocument;
 import uk.ac.ebi.quickgo.geneproduct.common.GeneProductRepository;

--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfig.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfig.java
@@ -7,7 +7,6 @@ import uk.ac.ebi.quickgo.index.common.listener.LogStepListener;
 import uk.ac.ebi.quickgo.index.common.listener.SkipLoggerListener;
 import uk.ac.ebi.quickgo.index.common.writer.ListItemWriter;
 
-import com.google.common.base.Preconditions;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
@@ -81,14 +80,7 @@ public class CoTermsConfig {
 
     @Bean
     public Step coTermManualSummarizationStep(CoTermsConfigProperties coTermsConfigProperties) {
-        Preconditions.checkState(
-                !coTermsConfigProperties.getAll().equals(coTermsConfigProperties.getManual()),
-                "The output path for " +
-                        "manual and all " +
-                        "coterms files should not be the same, but they were both %s",
-                coTermsConfigProperties.getManual());
-
-        LOGGER.info("Created coTermManualSummarizationStep. Will write CoTerms to " + coTermsConfigProperties
+       LOGGER.info("Created coTermManualSummarizationStep. Will write CoTerms to " + coTermsConfigProperties
                 .getManual());
 
         return stepBuilders.get(CO_TERM_MANUAL_SUMMARIZATION_STEP)
@@ -105,13 +97,6 @@ public class CoTermsConfig {
 
     @Bean
     public Step coTermAllSummarizationStep(CoTermsConfigProperties coTermsConfigProperties) {
-        Preconditions.checkState(
-                !coTermsConfigProperties.getAll().equals(coTermsConfigProperties.getManual()),
-                "The output path for " +
-                        "manual and all " +
-                        "coterms files should not be the same, but they were both %s",
-                coTermsConfigProperties.getManual());
-
         LOGGER.info(
                 "Created coTermAllSummarizationStep. Will write CoTerms to " +
                         coTermsConfigProperties.getAll());

--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfigProperties.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfigProperties.java
@@ -1,5 +1,7 @@
 package uk.ac.ebi.quickgo.index.annotation.coterms;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Encapsulates configurable properties used during the generation of co-occurring term data.
  * This class' variables are populated using Spring's {@code @ConfigurationProperties} annotation in
@@ -36,6 +38,12 @@ public class CoTermsConfigProperties {
     }
 
     public String getManual() {
+        Preconditions.checkState(
+                !all.equals(manual),
+                "The output path for manual and all coterms files should not be the same, " +
+                        "but they were both %s",
+                manual);
+
         return manual;
     }
 
@@ -44,6 +52,12 @@ public class CoTermsConfigProperties {
     }
 
     public String getAll() {
+        Preconditions.checkState(
+                !all.equals(manual),
+                "The output path for manual and all coterms files should not be the same, " +
+                        "but they were both %s",
+                manual);
+
         return all;
     }
 

--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfigProperties.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfigProperties.java
@@ -1,67 +1,53 @@
 package uk.ac.ebi.quickgo.index.annotation.coterms;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 /**
  * Encapsulates configurable properties used during the generation of co-occurring term data.
+ * This class' variables are populated using Spring's {@code @ConfigurationProperties} annotation in
+ * {@link CoTermsConfig}.
  *
  * Created 02/03/17
  * @author Edd
  */
 public class CoTermsConfigProperties {
-    private int cotermsChunk;
-    private int coTermLogInterval;
-    private String manualCoTermsPath;
-    private String allCoTermsPath;
+    private static final int DEFAULT_CHUNK_SIZE = 1;
+    private static final int DEFAULT_LOG_INTERVAL = 1000;
+    private static final String DEFAULT_MANUAL_PATH = System.getProperty("user.home") + "/QuickGO/CoTermsManual";
+    private static final String DEFAULT_ALL_PATH = System.getProperty("user.home") + "/QuickGO/CoTermsAll";
 
-    private CoTermsConfigProperties(Builder builder) {
-        this.cotermsChunk = checkValidValue(builder.cotermsChunk);
-        this.coTermLogInterval = checkValidValue(builder.coTermLogInterval);
-        this.manualCoTermsPath = checkValidValue(builder.manualCoTermsPath);
-        this.allCoTermsPath = checkValidValue(builder.allCoTermsPath);
+    private int chunkSize = DEFAULT_CHUNK_SIZE;
+    private int loginterval = DEFAULT_LOG_INTERVAL;
+    private String manual = DEFAULT_MANUAL_PATH;
+    private String all = DEFAULT_ALL_PATH;
+
+    public int getChunkSize() {
+        return chunkSize;
     }
 
-    private <T> T checkValidValue(T value) {
-        checkArgument(value != null, "Value cannot be null");
-        return value;
+    public void setChunkSize(int chunkSize) {
+        this.chunkSize = chunkSize;
     }
 
-    int getCoTermsChunk() {return cotermsChunk;}
+    public int getLoginterval() {
+        return loginterval;
+    }
 
-    int getCoTermLogInterval() {return coTermLogInterval;}
+    public void setLoginterval(int loginterval) {
+        this.loginterval = loginterval;
+    }
 
-    String getManualCoTermsPath() {return manualCoTermsPath;}
+    public String getManual() {
+        return manual;
+    }
 
-    String getAllCoTermsPath() {return allCoTermsPath;}
+    public void setManual(String manual) {
+        this.manual = manual;
+    }
 
-    public static class Builder {
-        private int cotermsChunk;
-        private int coTermLogInterval;
-        private String manualCoTermsPath;
-        private String allCoTermsPath;
+    public String getAll() {
+        return all;
+    }
 
-        public Builder withCotermsChunk(int cotermsChunk) {
-            this.cotermsChunk = cotermsChunk;
-            return this;
-        }
-
-        public Builder withCoTermLogInterval(int coTermLogInterval) {
-            this.coTermLogInterval = coTermLogInterval;
-            return this;
-        }
-
-        public Builder withManualCoTermsPath(String manualCoTermsPath) {
-            this.manualCoTermsPath = manualCoTermsPath;
-            return this;
-        }
-
-        public Builder withAllCoTermsPath(String allCoTermsPath) {
-            this.allCoTermsPath = allCoTermsPath;
-            return this;
-        }
-
-        public CoTermsConfigProperties build() {
-            return new CoTermsConfigProperties(this);
-        }
+    public void setAll(String all) {
+        this.all = all;
     }
 }

--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfigProperties.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermsConfigProperties.java
@@ -1,0 +1,67 @@
+package uk.ac.ebi.quickgo.index.annotation.coterms;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Encapsulates configurable properties used during the generation of co-occurring term data.
+ *
+ * Created 02/03/17
+ * @author Edd
+ */
+public class CoTermsConfigProperties {
+    private int cotermsChunk;
+    private int coTermLogInterval;
+    private String manualCoTermsPath;
+    private String allCoTermsPath;
+
+    private CoTermsConfigProperties(Builder builder) {
+        this.cotermsChunk = checkValidValue(builder.cotermsChunk);
+        this.coTermLogInterval = checkValidValue(builder.coTermLogInterval);
+        this.manualCoTermsPath = checkValidValue(builder.manualCoTermsPath);
+        this.allCoTermsPath = checkValidValue(builder.allCoTermsPath);
+    }
+
+    private <T> T checkValidValue(T value) {
+        checkArgument(value != null, "Value cannot be null");
+        return value;
+    }
+
+    int getCoTermsChunk() {return cotermsChunk;}
+
+    int getCoTermLogInterval() {return coTermLogInterval;}
+
+    String getManualCoTermsPath() {return manualCoTermsPath;}
+
+    String getAllCoTermsPath() {return allCoTermsPath;}
+
+    public static class Builder {
+        private int cotermsChunk;
+        private int coTermLogInterval;
+        private String manualCoTermsPath;
+        private String allCoTermsPath;
+
+        public Builder withCotermsChunk(int cotermsChunk) {
+            this.cotermsChunk = cotermsChunk;
+            return this;
+        }
+
+        public Builder withCoTermLogInterval(int coTermLogInterval) {
+            this.coTermLogInterval = coTermLogInterval;
+            return this;
+        }
+
+        public Builder withManualCoTermsPath(String manualCoTermsPath) {
+            this.manualCoTermsPath = manualCoTermsPath;
+            return this;
+        }
+
+        public Builder withAllCoTermsPath(String allCoTermsPath) {
+            this.allCoTermsPath = allCoTermsPath;
+            return this;
+        }
+
+        public CoTermsConfigProperties build() {
+            return new CoTermsConfigProperties(this);
+        }
+    }
+}

--- a/indexing/src/main/resources/application.properties
+++ b/indexing/src/main/resources/application.properties
@@ -20,4 +20,4 @@ indexing.annotation.header.lines=21
 indexing.annotation.skip.limit=100
 
 indexing.coterm.loginterval=1000
-indexing.coterms.chunk.size=1
+indexing.coterms.chunkSize=1

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingBatchIT.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingBatchIT.java
@@ -2,7 +2,7 @@ package uk.ac.ebi.quickgo.index.annotation;
 
 import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationRepository;
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 import uk.ac.ebi.quickgo.index.common.JobTestRunnerConfig;
 
 import java.io.IOException;

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingBatchIT.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingBatchIT.java
@@ -2,16 +2,15 @@ package uk.ac.ebi.quickgo.index.annotation;
 
 import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationRepository;
+import uk.ac.ebi.quickgo.common.store.BasicTemporaryFolder;
 import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.index.annotation.coterms.CoTermsConfigProperties;
 import uk.ac.ebi.quickgo.index.common.JobTestRunnerConfig;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -21,8 +20,10 @@ import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.SpringApplicationContextLoader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -45,17 +46,16 @@ import static uk.ac.ebi.quickgo.index.annotation.coterms.CoTermsConfig.CO_TERM_M
 @ActiveProfiles(profiles = {"embeddedServer"})
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(
-        classes = {AnnotationIndexingConfig.class, JobTestRunnerConfig.class},
+        classes = {AnnotationIndexingBatchIT.TestConfig.class,
+                AnnotationIndexingConfig.class, JobTestRunnerConfig.class},
         loader = SpringApplicationContextLoader.class)
 public class AnnotationIndexingBatchIT {
 
-    @Value("${indexing.coterms.manual:#{systemProperties['user.dir']}/QuickGO/CoTermsManual}")
-    String manualCoTermsPath;
-    @Value("${indexing.coterms.all:#{systemProperties['user.dir']}/QuickGO/CoTermsAll}")
-    String allCoTermsPath;
-
     @ClassRule
     public static final TemporarySolrDataStore solrDataStore = new TemporarySolrDataStore();
+
+    @ClassRule
+    public static BasicTemporaryFolder basicTemporaryFolder = new BasicTemporaryFolder();
 
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
@@ -66,14 +66,6 @@ public class AnnotationIndexingBatchIT {
     @Before
     public void setUp() throws IOException {
         annotationRepository.deleteAll();
-        Files.deleteIfExists(Paths.get(manualCoTermsPath));
-        Files.deleteIfExists(Paths.get(allCoTermsPath));
-    }
-
-    @After
-    public void tearDown() throws IOException {
-        Files.deleteIfExists(Paths.get(manualCoTermsPath));
-        Files.deleteIfExists(Paths.get(allCoTermsPath));
     }
 
     @Test
@@ -133,11 +125,27 @@ public class AnnotationIndexingBatchIT {
         //Has finished
         BatchStatus status = jobExecution.getStatus();
         assertThat(status, is(BatchStatus.COMPLETED));
-
     }
 
     private List<String> getGeneProductIdsFromAnnotationDocuments(Iterable<AnnotationDocument> repoDocsWritten) {
         return StreamSupport.stream(repoDocsWritten.spliterator(), false).map(i -> i.geneProductId).collect(Collectors
                 .toList());
+    }
+
+    /**
+     * Configure properties used by co-term generation, using test values.
+     */
+    @Configuration
+    public static class TestConfig {
+        @Primary
+        @Bean
+        public CoTermsConfigProperties primaryCoTermsConfigProperties() {
+            CoTermsConfigProperties properties = new CoTermsConfigProperties();
+            properties.setChunkSize(1);
+            properties.setLoginterval(100);
+            properties.setManual(basicTemporaryFolder.getRoot().getAbsolutePath() + "/CoTermsManual");
+            properties.setAll(basicTemporaryFolder.getRoot().getAbsolutePath() + "/CoTermsAll");
+            return properties;
+        }
     }
 }

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingRetriesSolrWritesWithFailureIT.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingRetriesSolrWritesWithFailureIT.java
@@ -2,12 +2,11 @@ package uk.ac.ebi.quickgo.index.annotation;
 
 import org.junit.Before;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 import uk.ac.ebi.quickgo.index.common.JobTestRunnerConfig;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingRetriesSolrWritesWithSuccessIT.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/AnnotationIndexingRetriesSolrWritesWithSuccessIT.java
@@ -2,12 +2,11 @@ package uk.ac.ebi.quickgo.index.annotation;
 
 import org.junit.Before;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 import uk.ac.ebi.quickgo.index.common.JobTestRunnerConfig;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/CoTermIndexingBatchIT.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/CoTermIndexingBatchIT.java
@@ -95,7 +95,6 @@ public class CoTermIndexingBatchIT {
         //Has finished
         BatchStatus status = jobExecution.getStatus();
         assertThat(status, is(BatchStatus.COMPLETED));
-
     }
 
     /**
@@ -106,12 +105,12 @@ public class CoTermIndexingBatchIT {
         @Primary
         @Bean
         public CoTermsConfigProperties primaryCoTermsConfigProperties() {
-            return new CoTermsConfigProperties.Builder()
-                    .withCotermsChunk(1)
-                    .withCoTermLogInterval(1000)
-                    .withManualCoTermsPath(basicTemporaryFolder.getRoot().getAbsolutePath() + "/CoTermsManual")
-                    .withAllCoTermsPath(basicTemporaryFolder.getRoot().getAbsolutePath() + "/CoTermsAll")
-                    .build();
+            CoTermsConfigProperties properties = new CoTermsConfigProperties();
+            properties.setChunkSize(1);
+            properties.setLoginterval(1000);
+            properties.setManual(basicTemporaryFolder.getRoot().getAbsolutePath() + "/CoTermsManual");
+            properties.setAll(basicTemporaryFolder.getRoot().getAbsolutePath() + "/CoTermsAll");
+            return properties;
         }
     }
 }

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermConfigTest.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermConfigTest.java
@@ -16,12 +16,9 @@ public class CoTermConfigTest {
     @Test(expected = NullPointerException.class)
     public void manualAndAllOutputPathsWhenDifferentWillNotCauseAIllegalStateException(){
         CoTermsConfig coTermsConfig = new CoTermsConfig();
-        CoTermsConfigProperties properties = new CoTermsConfigProperties.Builder()
-                .withManualCoTermsPath(MANUAL_PATH)
-                .withAllCoTermsPath(ALL_PATH)
-                .withCoTermLogInterval(1)
-                .withCotermsChunk(1)
-                .build();
+        CoTermsConfigProperties properties = new CoTermsConfigProperties();
+        properties.setAll(ALL_PATH);
+        properties.setManual(MANUAL_PATH);
         coTermsConfig.coTermAllSummarizationStep(properties);
         coTermsConfig.coTermManualSummarizationStep(properties);
     }
@@ -29,24 +26,18 @@ public class CoTermConfigTest {
     @Test(expected = IllegalStateException.class)
     public void cannotHaveBothManualAndAllOutputPathsTheSameForCoTermsWhenCallingCoTermAllSummarizationStep(){
         CoTermsConfig coTermsConfig = new CoTermsConfig();
-        CoTermsConfigProperties properties = new CoTermsConfigProperties.Builder()
-                .withManualCoTermsPath(MANUAL_PATH)
-                .withAllCoTermsPath(MANUAL_PATH)
-                .withCoTermLogInterval(1)
-                .withCotermsChunk(1)
-                .build();
+        CoTermsConfigProperties properties = new CoTermsConfigProperties();
+        properties.setAll(MANUAL_PATH);
+        properties.setManual(MANUAL_PATH);
         coTermsConfig.coTermAllSummarizationStep(properties);
     }
 
     @Test(expected = IllegalStateException.class)
     public void cannotHaveBothManualAndAllOutputPathsTheSameForCoTermsCoTermManualSummarizationStep(){
         CoTermsConfig coTermsConfig = new CoTermsConfig();
-        CoTermsConfigProperties properties = new CoTermsConfigProperties.Builder()
-                .withManualCoTermsPath(MANUAL_PATH)
-                .withAllCoTermsPath(MANUAL_PATH)
-                .withCoTermLogInterval(1)
-                .withCotermsChunk(1)
-                .build();
+        CoTermsConfigProperties properties = new CoTermsConfigProperties();
+        properties.setAll(ALL_PATH);
+        properties.setManual(ALL_PATH);
         coTermsConfig.coTermAllSummarizationStep(properties);
     }
 }

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermConfigTest.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/annotation/coterms/CoTermConfigTest.java
@@ -16,25 +16,37 @@ public class CoTermConfigTest {
     @Test(expected = NullPointerException.class)
     public void manualAndAllOutputPathsWhenDifferentWillNotCauseAIllegalStateException(){
         CoTermsConfig coTermsConfig = new CoTermsConfig();
-        coTermsConfig.manualCoTermsPath = MANUAL_PATH;
-        coTermsConfig.allCoTermsPath = ALL_PATH;
-        coTermsConfig.coTermAllSummarizationStep();
-        coTermsConfig.coTermManualSummarizationStep();
+        CoTermsConfigProperties properties = new CoTermsConfigProperties.Builder()
+                .withManualCoTermsPath(MANUAL_PATH)
+                .withAllCoTermsPath(ALL_PATH)
+                .withCoTermLogInterval(1)
+                .withCotermsChunk(1)
+                .build();
+        coTermsConfig.coTermAllSummarizationStep(properties);
+        coTermsConfig.coTermManualSummarizationStep(properties);
     }
 
     @Test(expected = IllegalStateException.class)
     public void cannotHaveBothManualAndAllOutputPathsTheSameForCoTermsWhenCallingCoTermAllSummarizationStep(){
         CoTermsConfig coTermsConfig = new CoTermsConfig();
-        coTermsConfig.manualCoTermsPath = MANUAL_PATH;
-        coTermsConfig.allCoTermsPath = MANUAL_PATH;
-        coTermsConfig.coTermAllSummarizationStep();
+        CoTermsConfigProperties properties = new CoTermsConfigProperties.Builder()
+                .withManualCoTermsPath(MANUAL_PATH)
+                .withAllCoTermsPath(MANUAL_PATH)
+                .withCoTermLogInterval(1)
+                .withCotermsChunk(1)
+                .build();
+        coTermsConfig.coTermAllSummarizationStep(properties);
     }
 
     @Test(expected = IllegalStateException.class)
     public void cannotHaveBothManualAndAllOutputPathsTheSameForCoTermsCoTermManualSummarizationStep(){
         CoTermsConfig coTermsConfig = new CoTermsConfig();
-        coTermsConfig.manualCoTermsPath = MANUAL_PATH;
-        coTermsConfig.allCoTermsPath = MANUAL_PATH;
-        coTermsConfig.coTermManualSummarizationStep();
+        CoTermsConfigProperties properties = new CoTermsConfigProperties.Builder()
+                .withManualCoTermsPath(MANUAL_PATH)
+                .withAllCoTermsPath(MANUAL_PATH)
+                .withCoTermLogInterval(1)
+                .withCotermsChunk(1)
+                .build();
+        coTermsConfig.coTermAllSummarizationStep(properties);
     }
 }

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/geneproduct/GeneProductIndexingBatchIT.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/geneproduct/GeneProductIndexingBatchIT.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.quickgo.index.geneproduct;
 
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 import uk.ac.ebi.quickgo.geneproduct.common.GeneProductDocument;
 import uk.ac.ebi.quickgo.geneproduct.common.GeneProductRepository;
 import uk.ac.ebi.quickgo.index.common.JobTestRunnerConfig;

--- a/indexing/src/test/java/uk/ac/ebi/quickgo/index/ontology/OntologyIndexingBatchIT.java
+++ b/indexing/src/test/java/uk/ac/ebi/quickgo/index/ontology/OntologyIndexingBatchIT.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.quickgo.index.ontology;
 
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 import uk.ac.ebi.quickgo.index.QuickGOIndexMain;
 import uk.ac.ebi.quickgo.index.common.DocumentReaderException;
 import uk.ac.ebi.quickgo.index.common.JobTestRunnerConfig;

--- a/indexing/src/test/resources/application.properties
+++ b/indexing/src/test/resources/application.properties
@@ -27,7 +27,7 @@ indexing.annotation.retries.maxInterval=2000
 indexing.annotation.retries.retryLimit=2
 
 ## ================= Co Terms Indexing =================
-indexing.coterm.loginterval=1000
-indexing.coterms.chunk.size=1
-indexing.coterms.manual=src/test/resources/CoTermsManual
+indexing.coterms.logInterval=1000
+indexing.coterms.chunkSize=1
+indexing.coterms.manual=qsrc/test/resources/CoTermsManual
 indexing.coterms.all=src/test/resources/CoTermsAll

--- a/indexing/src/test/resources/application.properties
+++ b/indexing/src/test/resources/application.properties
@@ -29,5 +29,5 @@ indexing.annotation.retries.retryLimit=2
 ## ================= Co Terms Indexing =================
 indexing.coterms.logInterval=1000
 indexing.coterms.chunkSize=1
-indexing.coterms.manual=qsrc/test/resources/CoTermsManual
+indexing.coterms.manual=src/test/resources/CoTermsManual
 indexing.coterms.all=src/test/resources/CoTermsAll

--- a/ontology-common/src/test/java/uk/ac/ebi/quickgo/ontology/common/OntologyRepositoryIT.java
+++ b/ontology-common/src/test/java/uk/ac/ebi/quickgo/ontology/common/OntologyRepositoryIT.java
@@ -1,7 +1,7 @@
 package uk.ac.ebi.quickgo.ontology.common;
 
 import uk.ac.ebi.quickgo.common.QueryUtils;
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 import uk.ac.ebi.quickgo.ontology.common.document.OntologyDocMocker;
 
 import java.io.IOException;

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.quickgo.ontology.controller;
 
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 import uk.ac.ebi.quickgo.graphics.model.GraphImageLayout;
 import uk.ac.ebi.quickgo.graphics.ontology.GraphImage;
 import uk.ac.ebi.quickgo.graphics.ontology.GraphImageResult;

--- a/quickgo-client/src/test/java/uk/ac/ebi/quickgo/client/service/search/ontology/OntologyUserQueryScoringIT.java
+++ b/quickgo-client/src/test/java/uk/ac/ebi/quickgo/client/service/search/ontology/OntologyUserQueryScoringIT.java
@@ -1,7 +1,7 @@
 package uk.ac.ebi.quickgo.client.service.search.ontology;
 
 import uk.ac.ebi.quickgo.client.QuickGOREST;
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 import uk.ac.ebi.quickgo.ontology.common.OntologyDocument;
 import uk.ac.ebi.quickgo.ontology.common.OntologyRepository;
 import uk.ac.ebi.quickgo.ontology.common.OntologyType;

--- a/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/SearchControllerSetup.java
+++ b/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/SearchControllerSetup.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.quickgo.rest.search;
 
-import uk.ac.ebi.quickgo.common.solr.TemporarySolrDataStore;
+import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 
 import java.util.stream.Stream;
 import org.junit.Before;


### PR DESCRIPTION
It was noticed that the tests for annotation indexing (which includes testing co-terms), and co-term writing, wasn't maintaining control over where the file was being written to. Also, multiple test classes with different concerns were writing to the same files.

This PR puts the co-term specific properties into a separate class, which is populated through @ConfigurationProperties, and an instance of which is provided as a @Bean. The tests then are able to override this bean directly, and can write to a temporary location (BasicTemporaryFolder).

NB. This move to @ConfigurationProperties seemed relevant since we have an ongoing effort to use this style of property configuration over @Value, as recommended by the Spring community.

NB2. The use of @ConfigurationProperties means we'll need to change 1 property in our application*.yml files regarding coterm chunk size: `indexing.coterms.chunk.size` is now `indexing.coterms.chunkSize` (due to spring's naming conventions).