### PR TITLE
Goa 2736 go and eco filter defaults

### DIFF
--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
@@ -67,6 +67,7 @@ public class AnnotationRequest {
 
     static final String DESCENDANTS_USAGE = "descendants";
     static final String EXACT_USAGE = "exact";
+    static final String SLIM_USAGE = "slim";
 
     /**
      * indicates which fields should be looked at when creating filters
@@ -575,16 +576,16 @@ public class AnnotationRequest {
         if (filterMap.containsKey(idField)) {
             // term id provided
             switch (usageValue) {
+                case SLIM_USAGE:
                 case DESCENDANTS_USAGE:
                     request = Optional.of(filterBuilder.addProperty(usageValue)
-                            .addProperty(idField, filterMap.get(idField))
+                            .addProperty(idParam, filterMap.get(idField))
                             .addProperty(relationshipsParam, filterMap.get(relationshipsParam))
                             .build());
                     break;
                 case EXACT_USAGE:
                 default:
                     request = Optional.of(filterBuilder.addProperty(idField, filterMap.get(idField))
-                            .addProperty(relationshipsParam, filterMap.get(relationshipsParam))
                             .build());
                     break;
             }

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequest.java
@@ -69,6 +69,9 @@ public class AnnotationRequest {
     static final String EXACT_USAGE = "exact";
     static final String SLIM_USAGE = "slim";
 
+    static final String DEFAULT_EVIDENCE_CODE_USAGE = DESCENDANTS_USAGE;
+    static final String DEFAULT_GO_USAGE = DESCENDANTS_USAGE;
+
     /**
      * indicates which fields should be looked at when creating filters
      */
@@ -86,9 +89,6 @@ public class AnnotationRequest {
             Searchable.WITH_FROM,
             Searchable.EXTENSION
     };
-
-    private static final String DEFAULT_EVIDENCE_CODE_USAGE = DESCENDANTS_USAGE;
-    private static final String DEFAULT_GO_USAGE = DESCENDANTS_USAGE;
 
     /**
      * At the moment the definition of the list is hardcoded because we only have need to display annotation and
@@ -387,7 +387,6 @@ public class AnnotationRequest {
     @Pattern(regexp = "^descendants|exact$", flags = Pattern.Flag.CASE_INSENSITIVE,
             message = "Invalid evidenceCodeUsage: ${validatedValue}")
     public String getEvidenceCodeUsage() {
-        // todo test: ensure can use it; ensure filter req doesn't have goUsage in sig--is just a simple request
         return filterMap.get(EVIDENCE_CODE_USAGE_FIELD) == null ?
                 DEFAULT_EVIDENCE_CODE_USAGE : filterMap.get(EVIDENCE_CODE_USAGE_FIELD)[0];
     }
@@ -428,7 +427,6 @@ public class AnnotationRequest {
     @Pattern(regexp = "^slim|descendants|exact$", flags = Pattern.Flag.CASE_INSENSITIVE,
             message = "Invalid goUsage: ${validatedValue}")
     public String getGoUsage() {
-        // todo test: ensure can use it; ensure filter req doesn't have goUsage in sig--is just a simple request
         return filterMap.get(GO_USAGE_FIELD) == null ? DEFAULT_GO_USAGE : filterMap.get(GO_USAGE_FIELD)[0];
     }
 

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AbstractFilterAnnotationByOntologyRESTIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AbstractFilterAnnotationByOntologyRESTIT.java
@@ -121,6 +121,29 @@ public abstract class AbstractFilterAnnotationByOntologyRESTIT {
     }
 
     @Test
+    public void defaultFilterFor1TermBy1ValidDescendant() throws Exception {
+        annotationRepository.save(createAnnotationDocWithId(createGPId(1), ontologyId(1)));
+        annotationRepository.save(createAnnotationDocWithId(createGPId(2), ontologyId(2)));
+        annotationRepository.save(createAnnotationDocWithId(createGPId(3), ontologyId(3)));
+
+        expectRestCallHasDescendants(singletonList(ontologyId(1)), emptyList(),
+                singletonList(singletonList(ontologyId(3))));
+
+        ResultActions response = mockMvc.perform(
+                get(SEARCH_RESOURCE)
+                        .param(idParam, ontologyId(1)));
+
+        response.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(contentTypeToBeJson())
+                .andExpect(pageInfoExists())
+                .andExpect(totalNumOfResults(1))
+                .andExpect(fieldsInAllResultsExist(1))
+                .andExpect(fieldDoesNotExist(SLIMMED_ID_FIELD))
+                .andExpect(valuesOccurInField(idParam, ontologyId(3)));
+    }
+
+    @Test
     public void filterFor1TermBy1ValidDescendant() throws Exception {
         annotationRepository.save(createAnnotationDocWithId(createGPId(1), ontologyId(1)));
         annotationRepository.save(createAnnotationDocWithId(createGPId(2), ontologyId(2)));

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerIT.java
@@ -68,6 +68,7 @@ public class AnnotationControllerIT {
     private static final String WITH_FROM_PATH = "withFrom.*.connectedXrefs";
     //Configuration
     private static final int NUMBER_OF_GENERIC_DOCS = 3;
+    public static final String EXACT_USAGE = "exact";
     private MockMvc mockMvc;
     private List<AnnotationDocument> genericDocs;
     @Autowired
@@ -591,7 +592,9 @@ public class AnnotationControllerIT {
     public void successfullyLookupAnnotationsByGoId() throws Exception {
 
         ResultActions response = mockMvc.perform(
-                get(RESOURCE_URL + "/search").param(GO_ID_PARAM.getName(), AnnotationDocMocker.GO_ID));
+                get(RESOURCE_URL + "/search")
+                        .param(GO_ID_PARAM.getName(), AnnotationDocMocker.GO_ID)
+                        .param(GO_USAGE_PARAM.getName(), EXACT_USAGE));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -604,7 +607,9 @@ public class AnnotationControllerIT {
     @Test
     public void successfullyLookupAnnotationsByGoIdCaseInsensitive() throws Exception {
         ResultActions response = mockMvc.perform(
-                get(RESOURCE_URL + "/search").param(GO_ID_PARAM.getName(), AnnotationDocMocker.GO_ID.toLowerCase()));
+                get(RESOURCE_URL + "/search")
+                        .param(GO_ID_PARAM.getName(), AnnotationDocMocker.GO_ID.toLowerCase())
+                        .param(GO_USAGE_PARAM.getName(), EXACT_USAGE));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -616,9 +621,10 @@ public class AnnotationControllerIT {
 
     @Test
     public void failToFindAnnotationsWhenGoIdDoesntExist() throws Exception {
-
         ResultActions response = mockMvc.perform(
-                get(RESOURCE_URL + "/search").param(GO_ID_PARAM.getName(), MISSING_GO_ID));
+                get(RESOURCE_URL + "/search")
+                        .param(GO_ID_PARAM.getName(), MISSING_GO_ID)
+                        .param(GO_USAGE_PARAM.getName(), EXACT_USAGE));
 
         response.andDo(print())
                 .andExpect(status().isOk())
@@ -640,7 +646,9 @@ public class AnnotationControllerIT {
     @Test
     public void filterAnnotationsUsingSingleEvidenceCodeReturnsResults() throws Exception {
         ResultActions response = mockMvc.perform(
-                get(RESOURCE_URL + "/search").param(EVIDENCE_CODE_PARAM.getName(), AnnotationDocMocker.ECO_ID));
+                get(RESOURCE_URL + "/search")
+                        .param(EVIDENCE_CODE_PARAM.getName(), AnnotationDocMocker.ECO_ID)
+                        .param(EVIDENCE_CODE_USAGE_PARAM.getName(), EXACT_USAGE));
 
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
@@ -657,8 +665,10 @@ public class AnnotationControllerIT {
         repository.save(doc);
 
         ResultActions response = mockMvc.perform(
-                get(RESOURCE_URL + "/search").param(EVIDENCE_CODE_PARAM.getName(), AnnotationDocMocker.ECO_ID + ","
-                        + doc.evidenceCode + "," + MISSING_ECO_ID));
+                get(RESOURCE_URL + "/search")
+                        .param(EVIDENCE_CODE_PARAM.getName(),
+                                AnnotationDocMocker.ECO_ID + "," + doc.evidenceCode + "," + MISSING_ECO_ID)
+                        .param(EVIDENCE_CODE_USAGE_PARAM.getName(), EXACT_USAGE));
 
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
@@ -681,7 +691,8 @@ public class AnnotationControllerIT {
         ResultActions response = mockMvc.perform(
                 get(RESOURCE_URL + "/search").param(EVIDENCE_CODE_PARAM.getName(), AnnotationDocMocker.ECO_ID)
                         .param(EVIDENCE_CODE_PARAM.getName(), doc.evidenceCode)
-                        .param(EVIDENCE_CODE_PARAM.getName(), MISSING_ECO_ID));
+                        .param(EVIDENCE_CODE_PARAM.getName(), MISSING_ECO_ID)
+                        .param(EVIDENCE_CODE_USAGE_PARAM.getName(), EXACT_USAGE));
 
         response.andExpect(status().isOk())
                 .andExpect(contentTypeToBeJson())
@@ -696,7 +707,9 @@ public class AnnotationControllerIT {
     @Test
     public void filterByNonExistentEvidenceCodeReturnsZeroResults() throws Exception {
         ResultActions response = mockMvc.perform(
-                get(RESOURCE_URL + "/search").param(EVIDENCE_CODE_PARAM.getName(), MISSING_ECO_ID));
+                get(RESOURCE_URL + "/search")
+                        .param(EVIDENCE_CODE_PARAM.getName(), MISSING_ECO_ID)
+                        .param(EVIDENCE_CODE_USAGE_PARAM.getName(), EXACT_USAGE));
 
         response.andDo(print())
                 .andExpect(status().isOk())

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
@@ -32,6 +32,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.GO_ID_PARAM;
+import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.GO_USAGE_PARAM;
 import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.TAXON_ID_PARAM;
 import static uk.ac.ebi.quickgo.annotation.controller.ResponseVerifier.contentTypeToBeJson;
 import static uk.ac.ebi.quickgo.annotation.controller.ResponseVerifier.totalNumOfResults;
@@ -63,6 +64,7 @@ public class AnnotationControllerStatisticsIT {
     private static final String REFERENCE_STATS_FIELD = "reference";
     private static final String TAXON_ID_STATS_FIELD = "taxonId";
     private static final String GO_ASPECT_STATS_FIELD = "aspect";
+    public static final String EXACT_USAGE = "exact";
 
     private MockMvc mockMvc;
 
@@ -177,6 +179,7 @@ public class AnnotationControllerStatisticsIT {
         ResultActions response = mockMvc.perform(
                 get(STATS_ENDPOINT)
                         .param(GO_ID_PARAM.getName(), filteringGoId)
+                        .param(GO_USAGE_PARAM.getName(), EXACT_USAGE)
         );
 
         assertStatsResponse(response, TAXON_ID_STATS_FIELD, 2, relevantTaxonIds);
@@ -219,6 +222,7 @@ public class AnnotationControllerStatisticsIT {
         ResultActions response = mockMvc.perform(
                 get(STATS_ENDPOINT)
                         .param(GO_ID_PARAM.getName(), filteringGoId)
+                        .param(GO_USAGE_PARAM.getName(), EXACT_USAGE)
         );
 
         assertStatsResponse(response, REFERENCE_STATS_FIELD, 2, relevantReferenceIds);
@@ -262,6 +266,7 @@ public class AnnotationControllerStatisticsIT {
         ResultActions response = mockMvc.perform(
                 get(STATS_ENDPOINT)
                         .param(GO_ID_PARAM.getName(), filteringGoId)
+                        .param(GO_USAGE_PARAM.getName(), EXACT_USAGE)
         );
 
         assertStatsResponse(response, EVIDENCE_CODE_STATS_FIELD, 2, relevantEvidenceCodes);
@@ -304,6 +309,7 @@ public class AnnotationControllerStatisticsIT {
         ResultActions response = mockMvc.perform(
                 get(STATS_ENDPOINT)
                         .param(GO_ID_PARAM.getName(), filteringGoId)
+                        .param(GO_USAGE_PARAM.getName(), EXACT_USAGE)
         );
 
         assertStatsResponse(response, ASSIGNED_BY_STATS_FIELD, 2, relevantAssignedBy);
@@ -377,6 +383,7 @@ public class AnnotationControllerStatisticsIT {
         ResultActions response = mockMvc.perform(
                 get(STATS_ENDPOINT)
                         .param(GO_ID_PARAM.getName(), filteringGoId)
+                        .param(GO_USAGE_PARAM.getName(), EXACT_USAGE)
         );
 
         assertStatsResponse(response, GO_ASPECT_STATS_FIELD, 2, relevantAspect);

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.EVIDENCE_CODE_USAGE_RELATIONS_PARAM;
 import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.GO_ID_PARAM;
 import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.GO_USAGE_RELATIONS_PARAM;
+import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.DEFAULT_EVIDENCE_CODE_USAGE;
+import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.DEFAULT_GO_USAGE;
 import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.DESCENDANTS_USAGE;
 import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.EXACT_USAGE;
 import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.GO_USAGE_RELATIONSHIPS;
@@ -129,11 +131,16 @@ public class AnnotationRequestTest {
 
     @Test
     public void setAndGetGoUsage() {
-        String usage = "exact";
+        String usage = EXACT_USAGE;
 
         annotationRequest.setGoUsage(usage);
 
         assertThat(annotationRequest.getGoUsage(), is(usage));
+    }
+
+    @Test
+    public void getDefaultGoUsage() {
+        assertThat(annotationRequest.getGoUsage(), is(DEFAULT_GO_USAGE));
     }
 
     @Test
@@ -273,6 +280,11 @@ public class AnnotationRequestTest {
         annotationRequest.setEvidenceCodeUsage(usage);
 
         assertThat(annotationRequest.getEvidenceCodeUsage(), is(usage));
+    }
+
+    @Test
+    public void getDefaultEvidenceCodeUsage() {
+        assertThat(annotationRequest.getEvidenceCodeUsage(), is(DEFAULT_EVIDENCE_CODE_USAGE));
     }
 
     @Test

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestTest.java
@@ -1,8 +1,10 @@
 package uk.ac.ebi.quickgo.annotation.model;
 
+import uk.ac.ebi.quickgo.annotation.common.AnnotationFields;
 import uk.ac.ebi.quickgo.rest.ParameterException;
 import uk.ac.ebi.quickgo.rest.search.request.FilterRequest;
 
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Rule;
@@ -14,9 +16,10 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.EVIDENCE_CODE_PARAM;
-import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.GO_ID_PARAM;
-import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.EVIDENCE_CODE_USAGE_RELATIONSHIPS;
+import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.EVIDENCE_CODE_USAGE_RELATIONS_PARAM;
+import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.GO_USAGE_RELATIONS_PARAM;
+import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.DESCENDANTS_USAGE;
+import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.EXACT_USAGE;
 import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.GO_USAGE_RELATIONSHIPS;
 
 /**
@@ -154,6 +157,72 @@ public class AnnotationRequestTest {
     }
 
     @Test
+    public void canCreateDefaultFilterWithGoIds() {
+        String goId = "GO:0000001";
+
+        annotationRequest.setGoId(goId);
+
+        FilterRequest request = FilterRequest.newBuilder()
+                .addProperty(DESCENDANTS_USAGE)
+                .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
+                .addProperty(GO_USAGE_RELATIONS_PARAM.getName())
+                .build();
+        List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
+        assertThat(filterRequests, contains(request));
+    }
+
+    @Test
+    public void canCreateDefaultFilterWithGoIdsAndGoUsageRelationships() {
+        String goId = "GO:0000001";
+        String relationships = "is_A";
+
+        annotationRequest.setGoId(goId);
+        annotationRequest.setGoUsageRelationships(relationships);
+
+        FilterRequest request = FilterRequest.newBuilder()
+                .addProperty(DESCENDANTS_USAGE)
+                .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
+                .addProperty(GO_USAGE_RELATIONS_PARAM.getName(), relationships.toLowerCase())
+                .build();
+        List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
+        assertThat(filterRequests, contains(request));
+    }
+
+    @Test
+    public void canCreateExactFilterWithGoIds() {
+        String goId = "GO:0000001";
+        String usage = EXACT_USAGE;
+
+        annotationRequest.setGoId(goId);
+        annotationRequest.setGoUsage(usage);
+
+        FilterRequest request = FilterRequest.newBuilder()
+                .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
+                .addProperty(GO_USAGE_RELATIONS_PARAM.getName())
+                .build();
+        List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
+        assertThat(filterRequests, contains(request));
+    }
+
+    @Test
+    public void canCreateExactFilterWithGoIdsAndGoUsageRelationships() {
+        String goId = "GO:0000001";
+        String usage = EXACT_USAGE;
+        String relationships = "is_A";
+
+        annotationRequest.setGoId(goId);
+        annotationRequest.setGoUsage(usage);
+        annotationRequest.setGoUsageRelationships(relationships);
+
+        FilterRequest request = FilterRequest.newBuilder()
+                .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
+                .addProperty(GO_USAGE_RELATIONS_PARAM.getName(), relationships.toLowerCase())
+                .build();
+        List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
+        assertThat(filterRequests, contains(request));
+    }
+
+    @Test
     public void createsFilterWithCaseInsensitiveGoUsageAndGoIds() {
         String usage = "descEndants";
         String goId = "GO:0000001";
@@ -163,7 +232,7 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(usage.toLowerCase())
-                .addProperty(GO_ID_PARAM.getName(), goId.toUpperCase())
+                .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
                 .addProperty(GO_USAGE_RELATIONSHIPS)
                 .build();
         assertThat(annotationRequest.createFilterRequests(),
@@ -180,17 +249,18 @@ public class AnnotationRequestTest {
         annotationRequest.setGoId(goId);
         annotationRequest.setGoUsageRelationships(relationships);
 
-        assertThat(annotationRequest.createFilterRequests(),
-                contains(FilterRequest.newBuilder()
-                        .addProperty(usage.toLowerCase())
-                        .addProperty(GO_ID_PARAM.getName(), goId.toUpperCase())
-                        .addProperty(GO_USAGE_RELATIONSHIPS, relationships.toLowerCase())
-                        .build()));
+        List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
+        FilterRequest request = FilterRequest.newBuilder()
+                .addProperty(usage.toLowerCase())
+                .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
+                .addProperty(GO_USAGE_RELATIONSHIPS, relationships.toLowerCase())
+                .build();
+        assertThat(filterRequests, contains(request));
     }
 
     @Test(expected = ParameterException.class)
     public void cannotCreateFilterWithUsageAndNoGoUsageIds() {
-        annotationRequest.setGoUsage("descendants");
+        annotationRequest.setGoUsage(DESCENDANTS_USAGE);
 
         annotationRequest.createFilterRequests();
     }
@@ -198,7 +268,7 @@ public class AnnotationRequestTest {
     //-----------------
     @Test
     public void setAndGetEvidenceCodeUsage() {
-        String usage = "descendants";
+        String usage = DESCENDANTS_USAGE;
 
         annotationRequest.setEvidenceCodeUsage(usage);
 
@@ -228,6 +298,72 @@ public class AnnotationRequestTest {
     }
 
     @Test
+    public void canCreateDefaultFilterWithEcoIds() {
+        String ecoId = "ECO:0000001";
+
+        annotationRequest.setEvidenceCode(ecoId);
+
+        FilterRequest request = FilterRequest.newBuilder()
+                .addProperty(DESCENDANTS_USAGE)
+                .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, ecoId.toUpperCase())
+                .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName())
+                .build();
+        List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
+        assertThat(filterRequests, contains(request));
+    }
+
+    @Test
+    public void canCreateDefaultFilterWithEcoIdsAndEcoUsageRelationships() {
+        String ecoId = "ECO:0000001";
+        String relationships = "is_A";
+
+        annotationRequest.setEvidenceCode(ecoId);
+        annotationRequest.setEvidenceCodeUsageRelationships(relationships);
+
+        FilterRequest request = FilterRequest.newBuilder()
+                .addProperty(DESCENDANTS_USAGE)
+                .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, ecoId.toUpperCase())
+                .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName(), relationships.toLowerCase())
+                .build();
+        List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
+        assertThat(filterRequests, contains(request));
+    }
+
+    @Test
+    public void canCreateExactFilterWithEcoIds() {
+        String ecoId = "ECO:0000001";
+        String usage = EXACT_USAGE;
+
+        annotationRequest.setEvidenceCode(ecoId);
+        annotationRequest.setEvidenceCodeUsage(usage);
+
+        FilterRequest request = FilterRequest.newBuilder()
+                .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, ecoId.toUpperCase())
+                .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName())
+                .build();
+        List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
+        assertThat(filterRequests, contains(request));
+    }
+
+    @Test
+    public void canCreateExactFilterWithECOIdsAndECOUsageRelationships() {
+        String ecoId = "ECO:0000001";
+        String usage = EXACT_USAGE;
+        String relationships = "is_A";
+
+        annotationRequest.setEvidenceCode(ecoId);
+        annotationRequest.setEvidenceCodeUsage(usage);
+        annotationRequest.setEvidenceCodeUsageRelationships(relationships);
+
+        FilterRequest request = FilterRequest.newBuilder()
+                .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, ecoId.toUpperCase())
+                .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName(), relationships.toLowerCase())
+                .build();
+        List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
+        assertThat(filterRequests, contains(request));
+    }
+
+    @Test
     public void createsFilterWithCaseInsensitiveEvidenceCodeUsageAndIds() {
         String usage = "descEndants";
         String id = "ECO:0000001";
@@ -237,8 +373,8 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(usage.toLowerCase())
-                .addProperty(EVIDENCE_CODE_PARAM.getName(), id.toUpperCase())
-                .addProperty(EVIDENCE_CODE_USAGE_RELATIONSHIPS)
+                .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, id.toUpperCase())
+                .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName())
                 .build();
         assertThat(annotationRequest.createFilterRequests(),
                 contains(request));
@@ -257,8 +393,8 @@ public class AnnotationRequestTest {
         assertThat(annotationRequest.createFilterRequests(),
                 contains(FilterRequest.newBuilder()
                         .addProperty(usage.toLowerCase())
-                        .addProperty(EVIDENCE_CODE_PARAM.getName(), id.toUpperCase())
-                        .addProperty(EVIDENCE_CODE_USAGE_RELATIONSHIPS, relationships.toLowerCase())
+                        .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, id.toUpperCase())
+                        .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName(), relationships.toLowerCase())
                         .build()));
     }
 

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestTest.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.quickgo.annotation.model;
 
+import uk.ac.ebi.quickgo.annotation.AnnotationParameters;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationFields;
 import uk.ac.ebi.quickgo.rest.ParameterException;
 import uk.ac.ebi.quickgo.rest.search.request.FilterRequest;
@@ -17,6 +18,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.EVIDENCE_CODE_USAGE_RELATIONS_PARAM;
+import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.GO_ID_PARAM;
 import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.GO_USAGE_RELATIONS_PARAM;
 import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.DESCENDANTS_USAGE;
 import static uk.ac.ebi.quickgo.annotation.model.AnnotationRequest.EXACT_USAGE;
@@ -164,7 +166,7 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(DESCENDANTS_USAGE)
-                .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
+                .addProperty(AnnotationParameters.GO_ID_PARAM.getName(), goId.toUpperCase())
                 .addProperty(GO_USAGE_RELATIONS_PARAM.getName())
                 .build();
         List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
@@ -181,7 +183,7 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(DESCENDANTS_USAGE)
-                .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
+                .addProperty(GO_ID_PARAM.getName(), goId.toUpperCase())
                 .addProperty(GO_USAGE_RELATIONS_PARAM.getName(), relationships.toLowerCase())
                 .build();
         List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
@@ -198,14 +200,13 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
-                .addProperty(GO_USAGE_RELATIONS_PARAM.getName())
                 .build();
         List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
         assertThat(filterRequests, contains(request));
     }
 
     @Test
-    public void canCreateExactFilterWithGoIdsAndGoUsageRelationships() {
+    public void canCreateExactFilterWithGoIdsAndUnusedGoUsageRelationships() {
         String goId = "GO:0000001";
         String usage = EXACT_USAGE;
         String relationships = "is_A";
@@ -216,7 +217,6 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
-                .addProperty(GO_USAGE_RELATIONS_PARAM.getName(), relationships.toLowerCase())
                 .build();
         List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
         assertThat(filterRequests, contains(request));
@@ -232,7 +232,7 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(usage.toLowerCase())
-                .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
+                .addProperty(AnnotationParameters.GO_ID_PARAM.getName(), goId.toUpperCase())
                 .addProperty(GO_USAGE_RELATIONSHIPS)
                 .build();
         assertThat(annotationRequest.createFilterRequests(),
@@ -252,7 +252,7 @@ public class AnnotationRequestTest {
         List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(usage.toLowerCase())
-                .addProperty(AnnotationFields.Searchable.GO_ID, goId.toUpperCase())
+                .addProperty(AnnotationParameters.GO_ID_PARAM.getName(), goId.toUpperCase())
                 .addProperty(GO_USAGE_RELATIONSHIPS, relationships.toLowerCase())
                 .build();
         assertThat(filterRequests, contains(request));
@@ -305,7 +305,7 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(DESCENDANTS_USAGE)
-                .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, ecoId.toUpperCase())
+                .addProperty(AnnotationParameters.EVIDENCE_CODE_PARAM.getName(), ecoId.toUpperCase())
                 .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName())
                 .build();
         List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
@@ -322,7 +322,7 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(DESCENDANTS_USAGE)
-                .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, ecoId.toUpperCase())
+                .addProperty(AnnotationParameters.EVIDENCE_CODE_PARAM.getName(), ecoId.toUpperCase())
                 .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName(), relationships.toLowerCase())
                 .build();
         List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
@@ -339,14 +339,13 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, ecoId.toUpperCase())
-                .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName())
                 .build();
         List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
         assertThat(filterRequests, contains(request));
     }
 
     @Test
-    public void canCreateExactFilterWithECOIdsAndECOUsageRelationships() {
+    public void canCreateExactFilterWithECOIdsAndUnusedECOUsageRelationships() {
         String ecoId = "ECO:0000001";
         String usage = EXACT_USAGE;
         String relationships = "is_A";
@@ -357,7 +356,6 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, ecoId.toUpperCase())
-                .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName(), relationships.toLowerCase())
                 .build();
         List<FilterRequest> filterRequests = annotationRequest.createFilterRequests();
         assertThat(filterRequests, contains(request));
@@ -373,7 +371,7 @@ public class AnnotationRequestTest {
 
         FilterRequest request = FilterRequest.newBuilder()
                 .addProperty(usage.toLowerCase())
-                .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, id.toUpperCase())
+                .addProperty(AnnotationParameters.EVIDENCE_CODE_PARAM.getName(), id.toUpperCase())
                 .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName())
                 .build();
         assertThat(annotationRequest.createFilterRequests(),
@@ -393,7 +391,7 @@ public class AnnotationRequestTest {
         assertThat(annotationRequest.createFilterRequests(),
                 contains(FilterRequest.newBuilder()
                         .addProperty(usage.toLowerCase())
-                        .addProperty(AnnotationFields.Searchable.EVIDENCE_CODE, id.toUpperCase())
+                        .addProperty(AnnotationParameters.EVIDENCE_CODE_PARAM.getName(), id.toUpperCase())
                         .addProperty(EVIDENCE_CODE_USAGE_RELATIONS_PARAM.getName(), relationships.toLowerCase())
                         .build()));
     }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
@@ -529,44 +529,44 @@ public class AnnotationRequestValidationIT {
         assertThat(validator.validate(annotationRequest), hasSize(greaterThan(0)));
     }
 
-    //USAGE PARAMETERS
+    //GO USAGE PARAMETERS
     @Test
-    public void descendantsUsageIsValid() {
+    public void descendantsGoUsageIsValid() {
         annotationRequest.setGoUsage("descendants");
 
         assertThat(validator.validate(annotationRequest), hasSize(0));
     }
 
     @Test
-    public void slimUsageIsValid() {
+    public void slimGoUsageIsValid() {
         annotationRequest.setGoUsage("slim");
 
         assertThat(validator.validate(annotationRequest), hasSize(0));
     }
 
     @Test
-    public void exactUsageIsInvalid() {
+    public void exactGoUsageIsValid() {
         annotationRequest.setGoUsage("exact");
 
-        assertThat(validator.validate(annotationRequest), hasSize(1));
+        assertThat(validator.validate(annotationRequest), hasSize(0));
     }
 
     @Test
-    public void usageValueIsInvalid() {
+    public void goUsageValueIsInvalid() {
         annotationRequest.setGoUsage("thisDoesNotExistAsAValidUsage");
 
         assertThat(validator.validate(annotationRequest), hasSize(greaterThan(0)));
     }
 
     @Test
-    public void usageRelationshipIsValid() {
+    public void goUsageRelationshipIsValid() {
         annotationRequest.setGoUsageRelationships("is_a");
 
         assertThat(validator.validate(annotationRequest), hasSize(0));
     }
 
     @Test
-    public void usageRelationshipIsInvalid() {
+    public void goUsageRelationshipIsInvalid() {
         String invalidRel = "invalid_relationship";
 
         annotationRequest.setGoUsageRelationships(invalidRel);
@@ -579,11 +579,63 @@ public class AnnotationRequestValidationIT {
     }
 
     @Test(expected = ParameterException.class)
-    public void cannotCreateFilterWithUsageAndNoUsageIds() {
+    public void cannotCreateFilterWithGoUsageAndNoUsageIds() {
         annotationRequest.setGoUsage("descendants");
 
         annotationRequest.createFilterRequests();
     }
+
+    //---------------------------------------
+    //ECO USAGE PARAMETERS
+    @Test
+    public void descendantsEcoUsageIsValid() {
+        annotationRequest.setEvidenceCodeUsage("descendants");
+
+        assertThat(validator.validate(annotationRequest), hasSize(0));
+    }
+
+    @Test
+    public void exactEcoUsageIsValid() {
+        annotationRequest.setEvidenceCodeUsage("exact");
+
+        assertThat(validator.validate(annotationRequest), hasSize(0));
+    }
+
+    @Test
+    public void ecoUsageValueIsInvalid() {
+        annotationRequest.setEvidenceCodeUsage("thisDoesNotExistAsAValidUsage");
+
+        assertThat(validator.validate(annotationRequest), hasSize(greaterThan(0)));
+    }
+
+    @Test
+    public void ecoUsageRelationshipIsValid() {
+        annotationRequest.setEvidenceCodeUsageRelationships("is_a");
+
+        assertThat(validator.validate(annotationRequest), hasSize(0));
+    }
+
+    @Test
+    public void ecoUsageRelationshipIsInvalid() {
+        String invalidRel = "invalid_relationship";
+
+        annotationRequest.setEvidenceCodeUsageRelationships(invalidRel);
+
+        Set<ConstraintViolation<AnnotationRequest>> violations = validator.validate(annotationRequest);
+
+        assertThat(violations, hasSize(1));
+        assertThat(violations.iterator().next().getMessage(),
+                is(createRegexErrorMessage(USAGE_RELATIONSHIP_PARAM, invalidRel)));
+    }
+
+    @Test(expected = ParameterException.class)
+    public void cannotCreateFilterWithEcoUsageAndNoUsageIds() {
+        annotationRequest.setEvidenceCodeUsage("descendants");
+
+        annotationRequest.createFilterRequests();
+    }
+    //---------------------------------------
+
 
     //WITH/FROM PARAMETER
     @Test

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/AnnotationRequestValidationIT.java
@@ -602,6 +602,13 @@ public class AnnotationRequestValidationIT {
     }
 
     @Test
+    public void slimEcoUsageIsInvalid() {
+        annotationRequest.setEvidenceCodeUsage("slim");
+
+        assertThat(validator.validate(annotationRequest), hasSize(greaterThan(0)));
+    }
+
+    @Test
     public void ecoUsageValueIsInvalid() {
         annotationRequest.setEvidenceCodeUsage("thisDoesNotExistAsAValidUsage");
 

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/request/FilterRequest.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/request/FilterRequest.java
@@ -89,6 +89,12 @@ public class FilterRequest {
 
     }
 
+    @Override public String toString() {
+        return "FilterRequest{" +
+                "properties=" + properties +
+                '}';
+    }
+
     public static class Builder {
         private Map<String, List<String>> properties;
 

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/request/converter/FilterConverterFactory.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/request/converter/FilterConverterFactory.java
@@ -50,7 +50,6 @@ public class FilterConverterFactory {
                             "RequestConfig execution has not been handled " +
                                     "for signature (" + request.getSignature() + ") in " + filterConfigRetrieval);
             }
-
         } else {
             throw new IllegalStateException(
                     "Could not find signature (" + request.getSignature() + ") in " + filterConfigRetrieval);


### PR DESCRIPTION
Jira user story info:

**AS** the annotation GO term and ECO term filter 
**I WOULD LIKE TO** always specify the goUsage / evidenceCodeUsage value 
**SO THAT I CAN** know explicitly what filter value I am asking for.

**AS** a client of the QuickGO API 
**I WOULD LIKE TO** get descendants as default for goUsage / evidenceCodeUsage 
**SO THAT I CAN**  omit that filter value if I want.
 
_Scenarios:_
goId=XX&goUsage=exact => exact on XX
goId=XX&goUsage=descendants => descendants of XX
goId=XX => descendants of XX
goId=XX&goUsage=slim => slim of XX
