### PR TITLE
aligns quickgo-client's aspect filter with that of the contents of the ontology core

### DIFF
--- a/quickgo-client/src/main/java/uk/ac/ebi/quickgo/client/model/ontology/OntologyRequest.java
+++ b/quickgo-client/src/main/java/uk/ac/ebi/quickgo/client/model/ontology/OntologyRequest.java
@@ -56,7 +56,7 @@ public class OntologyRequest {
         setters
      */
     @ApiModelProperty(value = "Further filters the results of the main query based on values chosen from " +
-            "the aspect field", example = "biological_process")
+            "the aspect field", allowableValues = "Component,Function,Process", example = "Process")
     private String[] aspect;
 
     @ApiModelProperty(value = "Further filters the results of the main query based on a value chosen from " +
@@ -113,7 +113,7 @@ public class OntologyRequest {
         this.facet = facet;
     }
 
-    @ArrayPattern(regexp = "biological_process|molecular_function|cellular_component",
+    @ArrayPattern(regexp = "Process|Function|Component",
             paramName = "aspect",
             flags = Flag.CASE_INSENSITIVE)
     public String[] getAspect() {

--- a/quickgo-client/src/test/java/uk/ac/ebi/quickgo/client/model/ontology/OntologyRequestValidationIT.java
+++ b/quickgo-client/src/test/java/uk/ac/ebi/quickgo/client/model/ontology/OntologyRequestValidationIT.java
@@ -177,20 +177,23 @@ public class OntologyRequestValidationIT {
     }
 
     @Test
-    public void aspectWithMixedCasingIsValid() {
-        String mixedCaseAspect = "BiOlOgIcAl_PrOcEsS";
-        ontologyRequest.setAspect(mixedCaseAspect);
-
-        assertThat(validator.validate(ontologyRequest), hasSize(0));
-    }
-
-    @Test
     public void providedFilterByAspectValuesAreAllValid() throws Exception {
-        Arrays.asList("biological_process", "molecular_function", "cellular_component")
+        Arrays.asList("Process", "PRoceSs", "Function", "funCtioN", "Component", "compONent")
                 .forEach(aspect -> {
                             ontologyRequest.setAspect(aspect);
                             assertThat("Aspect value: " + aspect + " is invalid",
                                     validator.validate(ontologyRequest), hasSize(0));
+                        }
+                );
+    }
+
+    @Test
+    public void providedFilterByAspectValuesAreAllInvalid() throws Exception {
+        Arrays.asList("biological_process", "molecular_function", "cellular_component")
+                .forEach(aspect -> {
+                            ontologyRequest.setAspect(aspect);
+                            assertThat("Aspect value: " + aspect + " is valid, but should be invalid",
+                                    validator.validate(ontologyRequest), hasSize(1));
                         }
                 );
     }

--- a/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/SearchControllerSetup.java
+++ b/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/SearchControllerSetup.java
@@ -164,7 +164,7 @@ public abstract class SearchControllerSetup {
     }
 
     // filter queries ---------------------------------------------------------
-    protected void checkInvalidFilterQueryResponse(String query, Param... filterQuery) throws Exception {
+    protected ResultActions checkInvalidFilterQueryResponse(String query, Param... filterQuery) throws Exception {
         MockHttpServletRequestBuilder clientRequest = createRequest(query);
 
         addFiltersToRequest(clientRequest, filterQuery);
@@ -174,6 +174,8 @@ public abstract class SearchControllerSetup {
                 .andExpect(MockMvcResultMatchers.status().isBadRequest());
 
         checkErrorMessage(result);
+
+        return result;
     }
 
     protected ResultActions checkValidFilterQueryResponse(String query, int expectedResponseSize,


### PR DESCRIPTION
As a QuickGO user,

When I search for ontology aspects, I would like to be able to search for Process/Function/Component (case insensitive).

Then I want to retrieve all terms matching the requested aspect.

Note. (Previously, one could search for, e.g., biological_process, but this behaviour was changed to the more user friendly versions Process/Function/Component).