### PR TITLE
Align geneproduct indexing with that of annotations

### DIFF
--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/AnnotationConfig.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/annotation/AnnotationConfig.java
@@ -48,7 +48,6 @@ public class AnnotationConfig {
     @Autowired
     private SolrTemplate annotationTemplate;
 
-
     @Bean
     MultiResourceItemReader<Annotation> annotationMultiFileReader() {
         MultiResourceItemReader<Annotation> reader = new MultiResourceItemReader<>();

--- a/indexing/src/main/java/uk/ac/ebi/quickgo/index/geneproduct/GeneProductConfig.java
+++ b/indexing/src/main/java/uk/ac/ebi/quickgo/index/geneproduct/GeneProductConfig.java
@@ -2,18 +2,14 @@ package uk.ac.ebi.quickgo.index.geneproduct;
 
 import uk.ac.ebi.quickgo.geneproduct.common.GeneProductDocument;
 import uk.ac.ebi.quickgo.geneproduct.common.GeneProductRepoConfig;
-import uk.ac.ebi.quickgo.geneproduct.common.GeneProductRepository;
-import uk.ac.ebi.quickgo.index.common.SolrCrudRepoWriter;
+import uk.ac.ebi.quickgo.index.common.SolrServerWriter;
 import uk.ac.ebi.quickgo.index.common.listener.LogJobListener;
 import uk.ac.ebi.quickgo.index.common.listener.SkipLoggerListener;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobExecutionListener;
-import org.springframework.batch.core.SkipListener;
-import org.springframework.batch.core.Step;
+import org.springframework.batch.core.*;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
@@ -37,6 +33,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
+import org.springframework.data.solr.core.SolrTemplate;
 import org.springframework.retry.backoff.BackOffPolicy;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 
@@ -83,13 +80,21 @@ public class GeneProductConfig {
     private int retryLimit;
 
     @Autowired
-    private GeneProductRepository geneProductRepository;
+    private SolrTemplate geneProductTemplate;
 
     @Bean
     public Job geneProductJob() {
         return jobBuilders.get(GENE_PRODUCT_INDEXING_JOB_NAME)
                 .start(geneProductIndexingStep())
                 .listener(logJobListener())
+                // commit the documents to the solr server
+                .listener(new JobExecutionListener() {
+                    @Override public void beforeJob(JobExecution jobExecution) {}
+
+                    @Override public void afterJob(JobExecution jobExecution) {
+                        geneProductTemplate.commit();
+                    }
+                })
                 .build();
     }
 
@@ -184,7 +189,7 @@ public class GeneProductConfig {
 
     @Bean
     ItemWriter<GeneProductDocument> geneProductRepositoryWriter() {
-        return new SolrCrudRepoWriter<>(geneProductRepository);
+        return new SolrServerWriter<>(geneProductTemplate.getSolrClient());
     }
 
     private JobExecutionListener logJobListener() {

--- a/solr-cores/src/main/cores/geneproduct/conf/solrconfig.xml
+++ b/solr-cores/src/main/cores/geneproduct/conf/solrconfig.xml
@@ -385,19 +385,19 @@
              have some sort of hard autoCommit to limit the log size.
           -->
         <autoCommit>
-            <maxTime>${solr.autoCommit.maxTime:15000}</maxTime>
-            <openSearcher>true</openSearcher>
+            <maxTime>${auto.commit.time.millis:30000}</maxTime>
+            <openSearcher>false</openSearcher>
         </autoCommit>
 
         <!-- softAutoCommit is like autoCommit except it causes a
              'soft' commit which only ensures that changes are visible
              but does not ensure that data is synced to disk.  This is
              faster and more near-realtime friendly than a hard commit.
-          -->
 
-        <autoSoftCommit>
-            <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
-        </autoSoftCommit>
+
+         <autoSoftCommit>
+           <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
+         </autoSoftCommit> -->
 
         <!-- Update Related Event Listeners
 
@@ -987,93 +987,93 @@
          (SearchHandler) can be registered multiple times with different
          names (and different init parameters)
       -->
-    <requestHandler name="/browse" class="solr.SearchHandler">
-        <lst name="defaults">
-            <str name="echoParams">explicit</str>
+    <!--<requestHandler name="/browse" class="solr.SearchHandler">-->
+    <!--<lst name="defaults">-->
+    <!--<str name="echoParams">explicit</str>-->
 
-            <!-- VelocityResponseWriter settings -->
-            <str name="wt">velocity</str>
-            <str name="v.template">browse</str>
-            <str name="v.layout">layout</str>
-            <str name="title">Solritas</str>
+    <!--&lt;!&ndash; VelocityResponseWriter settings &ndash;&gt;-->
+    <!--<str name="wt">velocity</str>-->
+    <!--<str name="v.template">browse</str>-->
+    <!--<str name="v.layout">layout</str>-->
+    <!--<str name="title">Solritas</str>-->
 
-            <!-- Query settings -->
-            <str name="defType">edismax</str>
-            <str name="qf">
-                text^0.5 features^1.0 name^1.2 sku^1.5 id^10.0 manu^1.1 cat^1.4
-                title^10.0 description^5.0 keywords^5.0 author^2.0 resourcename^1.0
-            </str>
-            <str name="df">text</str>
-            <str name="mm">100%</str>
-            <str name="q.alt">*:*</str>
-            <str name="rows">10</str>
-            <str name="fl">*,score</str>
+    <!--&lt;!&ndash; Query settings &ndash;&gt;-->
+    <!--<str name="defType">edismax</str>-->
+    <!--<str name="qf">-->
+    <!--text^0.5 features^1.0 name^1.2 sku^1.5 id^10.0 manu^1.1 cat^1.4-->
+    <!--title^10.0 description^5.0 keywords^5.0 author^2.0 resourcename^1.0-->
+    <!--</str>-->
+    <!--<str name="df">text</str>-->
+    <!--<str name="mm">100%</str>-->
+    <!--<str name="q.alt">*:*</str>-->
+    <!--<str name="rows">10</str>-->
+    <!--<str name="fl">*,score</str>-->
 
-            <str name="mlt.qf">
-                text^0.5 features^1.0 name^1.2 sku^1.5 id^10.0 manu^1.1 cat^1.4
-                title^10.0 description^5.0 keywords^5.0 author^2.0 resourcename^1.0
-            </str>
-            <str name="mlt.fl">text,features,name,sku,id,manu,cat,title,description,keywords,author,resourcename</str>
-            <int name="mlt.count">3</int>
+    <!--<str name="mlt.qf">-->
+    <!--text^0.5 features^1.0 name^1.2 sku^1.5 id^10.0 manu^1.1 cat^1.4-->
+    <!--title^10.0 description^5.0 keywords^5.0 author^2.0 resourcename^1.0-->
+    <!--</str>-->
+    <!--<str name="mlt.fl">text,features,name,sku,id,manu,cat,title,description,keywords,author,resourcename</str>-->
+    <!--<int name="mlt.count">3</int>-->
 
-            <!-- Faceting defaults -->
-            <str name="facet">on</str>
-            <str name="facet.field">cat</str>
-            <str name="facet.field">manu_exact</str>
-            <str name="facet.field">content_type</str>
-            <str name="facet.field">author_s</str>
-            <str name="facet.query">ipod</str>
-            <str name="facet.query">GB</str>
-            <str name="facet.mincount">1</str>
-            <str name="facet.pivot">cat,inStock</str>
-            <str name="facet.range.other">after</str>
-            <str name="facet.range">price</str>
-            <int name="f.price.facet.range.start">0</int>
-            <int name="f.price.facet.range.end">600</int>
-            <int name="f.price.facet.range.gap">50</int>
-            <str name="facet.range">popularity</str>
-            <int name="f.popularity.facet.range.start">0</int>
-            <int name="f.popularity.facet.range.end">10</int>
-            <int name="f.popularity.facet.range.gap">3</int>
-            <str name="facet.range">manufacturedate_dt</str>
-            <str name="f.manufacturedate_dt.facet.range.start">NOW/YEAR-10YEARS</str>
-            <str name="f.manufacturedate_dt.facet.range.end">NOW</str>
-            <str name="f.manufacturedate_dt.facet.range.gap">+1YEAR</str>
-            <str name="f.manufacturedate_dt.facet.range.other">before</str>
-            <str name="f.manufacturedate_dt.facet.range.other">after</str>
+    <!--&lt;!&ndash; Faceting defaults &ndash;&gt;-->
+    <!--<str name="facet">on</str>-->
+    <!--<str name="facet.field">cat</str>-->
+    <!--<str name="facet.field">manu_exact</str>-->
+    <!--<str name="facet.field">content_type</str>-->
+    <!--<str name="facet.field">author_s</str>-->
+    <!--<str name="facet.query">ipod</str>-->
+    <!--<str name="facet.query">GB</str>-->
+    <!--<str name="facet.mincount">1</str>-->
+    <!--<str name="facet.pivot">cat,inStock</str>-->
+    <!--<str name="facet.range.other">after</str>-->
+    <!--<str name="facet.range">price</str>-->
+    <!--<int name="f.price.facet.range.start">0</int>-->
+    <!--<int name="f.price.facet.range.end">600</int>-->
+    <!--<int name="f.price.facet.range.gap">50</int>-->
+    <!--<str name="facet.range">popularity</str>-->
+    <!--<int name="f.popularity.facet.range.start">0</int>-->
+    <!--<int name="f.popularity.facet.range.end">10</int>-->
+    <!--<int name="f.popularity.facet.range.gap">3</int>-->
+    <!--<str name="facet.range">manufacturedate_dt</str>-->
+    <!--<str name="f.manufacturedate_dt.facet.range.start">NOW/YEAR-10YEARS</str>-->
+    <!--<str name="f.manufacturedate_dt.facet.range.end">NOW</str>-->
+    <!--<str name="f.manufacturedate_dt.facet.range.gap">+1YEAR</str>-->
+    <!--<str name="f.manufacturedate_dt.facet.range.other">before</str>-->
+    <!--<str name="f.manufacturedate_dt.facet.range.other">after</str>-->
 
-            <!-- Highlighting defaults -->
-            <str name="hl">on</str>
-            <str name="hl.fl">content features title name</str>
-            <str name="hl.encoder">html</str>
-            <str name="hl.simple.pre">&lt;b&gt;</str>
-            <str name="hl.simple.post">&lt;/b&gt;</str>
-            <str name="f.title.hl.fragsize">0</str>
-            <str name="f.title.hl.alternateField">title</str>
-            <str name="f.name.hl.fragsize">0</str>
-            <str name="f.name.hl.alternateField">name</str>
-            <str name="f.content.hl.snippets">3</str>
-            <str name="f.content.hl.fragsize">200</str>
-            <str name="f.content.hl.alternateField">content</str>
-            <str name="f.content.hl.maxAlternateFieldLength">750</str>
+    <!--&lt;!&ndash; Highlighting defaults &ndash;&gt;-->
+    <!--<str name="hl">on</str>-->
+    <!--<str name="hl.fl">content features title name</str>-->
+    <!--<str name="hl.encoder">html</str>-->
+    <!--<str name="hl.simple.pre">&lt;b&gt;</str>-->
+    <!--<str name="hl.simple.post">&lt;/b&gt;</str>-->
+    <!--<str name="f.title.hl.fragsize">0</str>-->
+    <!--<str name="f.title.hl.alternateField">title</str>-->
+    <!--<str name="f.name.hl.fragsize">0</str>-->
+    <!--<str name="f.name.hl.alternateField">name</str>-->
+    <!--<str name="f.content.hl.snippets">3</str>-->
+    <!--<str name="f.content.hl.fragsize">200</str>-->
+    <!--<str name="f.content.hl.alternateField">content</str>-->
+    <!--<str name="f.content.hl.maxAlternateFieldLength">750</str>-->
 
-            <!-- Spell checking defaults -->
-            <str name="spellcheck">on</str>
-            <str name="spellcheck.extendedResults">false</str>
-            <str name="spellcheck.count">5</str>
-            <str name="spellcheck.alternativeTermCount">2</str>
-            <str name="spellcheck.maxResultsForSuggest">5</str>
-            <str name="spellcheck.collate">true</str>
-            <str name="spellcheck.collateExtendedResults">true</str>
-            <str name="spellcheck.maxCollationTries">5</str>
-            <str name="spellcheck.maxCollations">3</str>
-        </lst>
+    <!--&lt;!&ndash; Spell checking defaults &ndash;&gt;-->
+    <!--<str name="spellcheck">on</str>-->
+    <!--<str name="spellcheck.extendedResults">false</str>-->
+    <!--<str name="spellcheck.count">5</str>-->
+    <!--<str name="spellcheck.alternativeTermCount">2</str>-->
+    <!--<str name="spellcheck.maxResultsForSuggest">5</str>-->
+    <!--<str name="spellcheck.collate">true</str>-->
+    <!--<str name="spellcheck.collateExtendedResults">true</str>-->
+    <!--<str name="spellcheck.maxCollationTries">5</str>-->
+    <!--<str name="spellcheck.maxCollations">3</str>-->
+    <!--</lst>-->
 
-        <!-- append spellchecking to our list of components -->
-        <arr name="last-components">
-            <str>spellcheck</str>
-        </arr>
-    </requestHandler>
+    <!--&lt;!&ndash; append spellchecking to our list of components &ndash;&gt;-->
+    <!--<arr name="last-components">-->
+    <!--<str>spellcheck</str>-->
+    <!--</arr>-->
+    <!--</requestHandler>-->
 
 
     <!-- Update Request Handler.


### PR DESCRIPTION
align geneproduct indexing writing with that of annotations, which has better document write rate: no searcher needs to be available during indexing; defer committing to solr itself + a final commit at end of indexing (as opposed to on every chunk write); use solrwriter class, which prints rate info