### PR TITLE
Goa 2943 distinct facet count in statistics

### DIFF
--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByType.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByType.java
@@ -18,7 +18,8 @@ public class StatisticsByType {
     private final List<StatisticsValue> values;
 
     public StatisticsByType(String type, int distinctValueCount) {
-        Preconditions.checkArgument(type != null && !type.isEmpty(), "Statistics type cannot be null or empty");
+        Preconditions.checkArgument(type != null && !type.isEmpty(), "Statistics type cannot be null or empty.");
+        Preconditions.checkArgument(distinctValueCount >= 0, "Distinct Value Count should be be greater than zero.");
         this.type = type;
         this.distinctValueCount = distinctValueCount;
         this.values = new ArrayList<>();
@@ -75,7 +76,7 @@ public class StatisticsByType {
     }
 
     private int truncateToTensOfThousands(int distinctValueCount) {
-        if (distinctValueCount < 10000) {
+        if (distinctValueCount < 10001) {
             return distinctValueCount;
         }
         int value = new BigDecimal(distinctValueCount).divide(new BigDecimal(1000), RoundingMode.HALF_UP).intValue();

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByType.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByType.java
@@ -12,16 +12,22 @@ import java.util.List;
  */
 public class StatisticsByType {
     private final String type;
+    private final int distinctValueCount;
     private final List<StatisticsValue> values;
 
-    public StatisticsByType(String type) {
+    public StatisticsByType(String type, int distinctValueCount) {
         Preconditions.checkArgument(type != null && !type.isEmpty(), "Statistics type cannot be null or empty");
         this.type = type;
+        this.distinctValueCount = distinctValueCount;
         this.values = new ArrayList<>();
     }
 
     public String getType() {
         return type;
+    }
+
+    public int getDistinctValueCount(){
+        return distinctValueCount;
     }
 
     public void addValue(StatisticsValue value) {
@@ -31,6 +37,12 @@ public class StatisticsByType {
 
     public List<StatisticsValue> getValues() {
         return Collections.unmodifiableList(values);
+    }
+
+    @Override public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + values.hashCode();
+        return result;
     }
 
     @Override public boolean equals(Object o) {
@@ -43,22 +55,19 @@ public class StatisticsByType {
 
         StatisticsByType that = (StatisticsByType) o;
 
-        if (!type.equals(that.type)) {
+        if (distinctValueCount != that.distinctValueCount) {
             return false;
         }
-        return values.equals(that.values);
-
-    }
-
-    @Override public int hashCode() {
-        int result = type.hashCode();
-        result = 31 * result + values.hashCode();
-        return result;
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+        return values != null ? values.equals(that.values) : that.values == null;
     }
 
     @Override public String toString() {
         return "StatisticsByType{" +
                 "type='" + type + '\'' +
+                ", distinctValueCount=" + distinctValueCount +
                 ", values=" + values +
                 '}';
     }

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByType.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByType.java
@@ -26,7 +26,7 @@ public class StatisticsByType {
         return type;
     }
 
-    public int getDistinctValueCount(){
+    public int getDistinctValueCount() {
         return truncateToTensOfThousands(distinctValueCount);
     }
 

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByType.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByType.java
@@ -1,6 +1,8 @@
 package uk.ac.ebi.quickgo.annotation.model;
 
 import com.google.common.base.Preconditions;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -76,6 +78,7 @@ public class StatisticsByType {
         if (distinctValueCount < 10000) {
             return distinctValueCount;
         }
-        return Integer.parseInt(String.format("%d000", distinctValueCount / 1000));
+        int value = new BigDecimal(distinctValueCount).divide(new BigDecimal(1000), RoundingMode.HALF_UP).intValue();
+        return Integer.parseInt(String.format("%d000", value));
     }
 }

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByType.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByType.java
@@ -27,7 +27,7 @@ public class StatisticsByType {
     }
 
     public int getDistinctValueCount(){
-        return distinctValueCount;
+        return truncateToTensOfThousands(distinctValueCount);
     }
 
     public void addValue(StatisticsValue value) {
@@ -70,5 +70,12 @@ public class StatisticsByType {
                 ", distinctValueCount=" + distinctValueCount +
                 ", values=" + values +
                 '}';
+    }
+
+    private int truncateToTensOfThousands(int distinctValueCount) {
+        if (distinctValueCount < 10000) {
+            return distinctValueCount;
+        }
+        return Integer.parseInt(String.format("%d000", distinctValueCount / 1000));
     }
 }

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/statistics/AnnotationStatisticsService.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/statistics/AnnotationStatisticsService.java
@@ -175,15 +175,12 @@ public class AnnotationStatisticsService implements StatisticsService {
         }
 
         private StatisticsByType createStatsType(AggregateResponse aggregation, long totalHits) {
-            StatisticsByType type = new StatisticsByType(aggregation.getName());
-
+            StatisticsByType type = new StatisticsByType(aggregation.getName(),aggregation.getDistinctValuesCount());
             Set<AggregationBucket> buckets = aggregation.getBuckets();
-
             buckets.stream()
                     .map(bucket -> createStatsValues(bucket, totalHits))
                     .flatMap(Collection::stream)
                     .forEach(type::addValue);
-
             return type;
         }
 

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
@@ -38,6 +38,7 @@ import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.TAXON_USAGE_PARA
 import static uk.ac.ebi.quickgo.annotation.controller.ResponseVerifier.contentTypeToBeJson;
 import static uk.ac.ebi.quickgo.annotation.controller.ResponseVerifier.totalNumOfResults;
 import static uk.ac.ebi.quickgo.annotation.controller.StatsResponseVerifier.keysInTypeWithinGroup;
+import static uk.ac.ebi.quickgo.annotation.controller.StatsResponseVerifier.numericValueForGroup;
 import static uk.ac.ebi.quickgo.annotation.controller.StatsResponseVerifier.totalHitsInGroup;
 
 /**
@@ -65,7 +66,8 @@ public class AnnotationControllerStatisticsIT {
     private static final String REFERENCE_STATS_FIELD = "reference";
     private static final String TAXON_ID_STATS_FIELD = "taxonId";
     private static final String GO_ASPECT_STATS_FIELD = "aspect";
-    public static final String EXACT_USAGE = "exact";
+    private static final String EXACT_USAGE = "exact";
+    private static final String DISTINCT_VALUE_COUNT = "distinctValueCount";
 
     private MockMvc mockMvc;
 
@@ -104,7 +106,7 @@ public class AnnotationControllerStatisticsIT {
     //----------- Ontology ID -----------//
     @Test
     public void statsForAllDocsContaining1OntologyIdReturns1OntologyIdStat() throws Exception {
-        executesAndAssertsCalculatedStatsForAttribute(GO_ID_STATS_FIELD, savedDocs, doc -> doc.goId);
+        executesAndAssertsCalculatedStatsForAttribute(GO_ID_STATS_FIELD, savedDocs, doc -> doc.goId, 1);
     }
 
     @Test
@@ -116,7 +118,7 @@ public class AnnotationControllerStatisticsIT {
         List<AnnotationDocument> savedDocsPlusOne = new ArrayList<>(savedDocs);
         savedDocsPlusOne.add(extraDoc);
 
-        executesAndAssertsCalculatedStatsForAttribute(GO_ID_STATS_FIELD, savedDocsPlusOne, doc -> doc.goId);
+        executesAndAssertsCalculatedStatsForAttribute(GO_ID_STATS_FIELD, savedDocsPlusOne, doc -> doc.goId, 2);
     }
 
     @Test
@@ -139,14 +141,14 @@ public class AnnotationControllerStatisticsIT {
                         .param(TAXON_USAGE_PARAM.getName(), EXACT_USAGE)
         );
 
-        assertStatsResponse(response, GO_ID_STATS_FIELD, 2, relevantGOIds);
+        assertStatsResponse(response, GO_ID_STATS_FIELD, 2, relevantGOIds, 2);
     }
 
     //----------- Taxon ID -----------//
     @Test
     public void statsForAllDocsContaining1TaxonIdReturns1TaxonIdStat() throws Exception {
         executesAndAssertsCalculatedStatsForAttribute(TAXON_ID_STATS_FIELD, savedDocs,
-                doc -> String.valueOf(doc.taxonId));
+                doc -> String.valueOf(doc.taxonId), 1);
     }
 
     @Test
@@ -159,7 +161,7 @@ public class AnnotationControllerStatisticsIT {
         savedDocsPlusOne.add(extraDoc);
 
         executesAndAssertsCalculatedStatsForAttribute(TAXON_ID_STATS_FIELD, savedDocsPlusOne,
-                doc -> String.valueOf(doc.taxonId));
+                doc -> String.valueOf(doc.taxonId), 2);
     }
 
     @Test
@@ -184,13 +186,13 @@ public class AnnotationControllerStatisticsIT {
                         .param(GO_USAGE_PARAM.getName(), EXACT_USAGE)
         );
 
-        assertStatsResponse(response, TAXON_ID_STATS_FIELD, 2, relevantTaxonIds);
+        assertStatsResponse(response, TAXON_ID_STATS_FIELD, 2, relevantTaxonIds, 2);
     }
 
     //----------- Reference -----------//
     @Test
     public void statsForAllDocsContaining1ReferenceIdReturns1ReferenceIdStat() throws Exception {
-        executesAndAssertsCalculatedStatsForAttribute(REFERENCE_STATS_FIELD, savedDocs, doc -> doc.reference);
+        executesAndAssertsCalculatedStatsForAttribute(REFERENCE_STATS_FIELD, savedDocs, doc -> doc.reference, 1);
     }
 
     @Test
@@ -202,7 +204,7 @@ public class AnnotationControllerStatisticsIT {
         List<AnnotationDocument> savedDocsPlusOne = new ArrayList<>(savedDocs);
         savedDocsPlusOne.add(extraDoc);
 
-        executesAndAssertsCalculatedStatsForAttribute(REFERENCE_STATS_FIELD, savedDocsPlusOne, doc -> doc.reference);
+        executesAndAssertsCalculatedStatsForAttribute(REFERENCE_STATS_FIELD, savedDocsPlusOne, doc -> doc.reference, 2);
     }
 
     @Test
@@ -227,13 +229,14 @@ public class AnnotationControllerStatisticsIT {
                         .param(GO_USAGE_PARAM.getName(), EXACT_USAGE)
         );
 
-        assertStatsResponse(response, REFERENCE_STATS_FIELD, 2, relevantReferenceIds);
+        assertStatsResponse(response, REFERENCE_STATS_FIELD, 2, relevantReferenceIds, 2);
     }
 
     //----------- Evidence code -----------//
     @Test
     public void statsForAllDocsContaining1EvidenceCodeReturns1EvidenceCodeStat() throws Exception {
-        executesAndAssertsCalculatedStatsForAttribute(EVIDENCE_CODE_STATS_FIELD, savedDocs, doc -> doc.evidenceCode);
+        executesAndAssertsCalculatedStatsForAttribute(EVIDENCE_CODE_STATS_FIELD, savedDocs, doc -> doc.evidenceCode,
+                1);
     }
 
     @Test
@@ -246,7 +249,7 @@ public class AnnotationControllerStatisticsIT {
         savedDocsPlusOne.add(extraDoc);
 
         executesAndAssertsCalculatedStatsForAttribute(EVIDENCE_CODE_STATS_FIELD, savedDocsPlusOne,
-                doc -> doc.evidenceCode);
+                doc -> doc.evidenceCode, 2);
     }
 
     @Test
@@ -271,13 +274,13 @@ public class AnnotationControllerStatisticsIT {
                         .param(GO_USAGE_PARAM.getName(), EXACT_USAGE)
         );
 
-        assertStatsResponse(response, EVIDENCE_CODE_STATS_FIELD, 2, relevantEvidenceCodes);
+        assertStatsResponse(response, EVIDENCE_CODE_STATS_FIELD, 2, relevantEvidenceCodes, 2);
     }
 
     //----------- Assigned by -----------//
     @Test
     public void statsForAllDocsContaining1AssignedByReturns1AssignedByStat() throws Exception {
-        executesAndAssertsCalculatedStatsForAttribute(ASSIGNED_BY_STATS_FIELD, savedDocs, doc -> doc.assignedBy);
+        executesAndAssertsCalculatedStatsForAttribute(ASSIGNED_BY_STATS_FIELD, savedDocs, doc -> doc.assignedBy, 1);
     }
 
     @Test
@@ -289,7 +292,8 @@ public class AnnotationControllerStatisticsIT {
         List<AnnotationDocument> savedDocsPlusOne = new ArrayList<>(savedDocs);
         savedDocsPlusOne.add(extraDoc);
 
-        executesAndAssertsCalculatedStatsForAttribute(ASSIGNED_BY_STATS_FIELD, savedDocsPlusOne, doc -> doc.assignedBy);
+        executesAndAssertsCalculatedStatsForAttribute(ASSIGNED_BY_STATS_FIELD, savedDocsPlusOne, doc -> doc
+                .assignedBy, 2);
     }
 
     @Test
@@ -314,44 +318,13 @@ public class AnnotationControllerStatisticsIT {
                         .param(GO_USAGE_PARAM.getName(), EXACT_USAGE)
         );
 
-        assertStatsResponse(response, ASSIGNED_BY_STATS_FIELD, 2, relevantAssignedBy);
-    }
-
-    /**
-     * Extracts all values of a given attribute, within all saved document, and then checks to see if the statistics run
-     * on that attribute are correct.
-     *
-     * @param attribute the attribute to run statistics on
-     * @param docs a collection of docs that the stats will be run on
-     * @param extractAttributeValuesFromDoc a function to extract the values of {@code statsType} from the saved
-     * documents
-     * @throws Exception if an error occurs whilst saving or retrieving documents
-     */
-    private void executesAndAssertsCalculatedStatsForAttribute(String attribute, Collection<AnnotationDocument> docs,
-            Function<AnnotationDocument, String> extractAttributeValuesFromDoc) throws Exception {
-        Set<String> extractedAttributeValues = selectValuesFromDocs(docs, extractAttributeValuesFromDoc);
-
-        ResultActions response = mockMvc.perform(get(STATS_ENDPOINT));
-
-        assertStatsResponse(response, attribute, docs.size(), extractedAttributeValues);
-    }
-
-    private void assertStatsResponse(ResultActions response, String statsType, int totalHits,
-            Collection<String> statsValues) throws Exception {
-        response.andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(contentTypeToBeJson())
-                .andExpect(totalNumOfResults(2))
-                .andExpect(totalHitsInGroup(ANNOTATION_GROUP, totalHits))
-                .andExpect(totalHitsInGroup(GENE_PRODUCT_GROUP, totalHits))
-                .andExpect(keysInTypeWithinGroup(ANNOTATION_GROUP, statsType, asArray(statsValues)))
-                .andExpect(keysInTypeWithinGroup(GENE_PRODUCT_GROUP, statsType, asArray(statsValues)));
+        assertStatsResponse(response, ASSIGNED_BY_STATS_FIELD, 2, relevantAssignedBy, 2);
     }
 
     //----------- GO aspect -----------//
     @Test
     public void statsForAllDocsContaining1AspectReturns1AspectByStat() throws Exception {
-        executesAndAssertsCalculatedStatsForAttribute(GO_ASPECT_STATS_FIELD, savedDocs, doc -> doc.goAspect);
+        executesAndAssertsCalculatedStatsForAttribute(GO_ASPECT_STATS_FIELD, savedDocs, doc -> doc.goAspect, 1);
     }
 
     @Test
@@ -363,7 +336,7 @@ public class AnnotationControllerStatisticsIT {
         List<AnnotationDocument> savedDocsPlusOne = new ArrayList<>(savedDocs);
         savedDocsPlusOne.add(extraDoc);
 
-        executesAndAssertsCalculatedStatsForAttribute(GO_ASPECT_STATS_FIELD, savedDocsPlusOne, doc -> doc.goAspect);
+        executesAndAssertsCalculatedStatsForAttribute(GO_ASPECT_STATS_FIELD, savedDocsPlusOne, doc -> doc.goAspect, 2);
     }
 
     @Test
@@ -388,17 +361,51 @@ public class AnnotationControllerStatisticsIT {
                         .param(GO_USAGE_PARAM.getName(), EXACT_USAGE)
         );
 
-        assertStatsResponse(response, GO_ASPECT_STATS_FIELD, 2, relevantAspect);
-    }
-
-    private String[] asArray(Collection<String> elements) {
-        return elements.stream().toArray(String[]::new);
+        assertStatsResponse(response, GO_ASPECT_STATS_FIELD, 2, relevantAspect, 2);
     }
 
     private static <T, D extends QuickGODocument> Set<T> selectValuesFromDocs(
             Collection<D> documents,
             Function<D, T> docTransformation) {
         return documents.stream().map(docTransformation).collect(Collectors.toSet());
+    }
+
+    /**
+     * Extracts all values of a given attribute, within all saved document, and then checks to see if the statistics run
+     * on that attribute are correct.
+     *
+     * @param attribute the attribute to run statistics on
+     * @param docs a collection of docs that the stats will be run on
+     * @param extractAttributeValuesFromDoc a function to extract the values of {@code statsType} from the saved
+     * documents
+     * @throws Exception if an error occurs whilst saving or retrieving documents
+     */
+    private void executesAndAssertsCalculatedStatsForAttribute(String attribute, Collection<AnnotationDocument> docs,
+            Function<AnnotationDocument, String> extractAttributeValuesFromDoc, int expectedDistinctValueCount)
+            throws Exception {
+        Set<String> extractedAttributeValues = selectValuesFromDocs(docs, extractAttributeValuesFromDoc);
+
+        ResultActions response = mockMvc.perform(get(STATS_ENDPOINT));
+
+        assertStatsResponse(response, attribute, docs.size(), extractedAttributeValues, expectedDistinctValueCount);
+    }
+
+    private void assertStatsResponse(ResultActions response, String statsType, int totalHits,
+            Collection<String> statsValues, int expectedDistinctValueCount) throws Exception {
+        response.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(contentTypeToBeJson())
+                .andExpect(totalNumOfResults(2))
+                .andExpect(totalHitsInGroup(ANNOTATION_GROUP, totalHits))
+                .andExpect(totalHitsInGroup(GENE_PRODUCT_GROUP, totalHits))
+                .andExpect(numericValueForGroup(ANNOTATION_GROUP, statsType, DISTINCT_VALUE_COUNT,
+                        expectedDistinctValueCount))
+                .andExpect(keysInTypeWithinGroup(ANNOTATION_GROUP, statsType, asArray(statsValues)))
+                .andExpect(keysInTypeWithinGroup(GENE_PRODUCT_GROUP, statsType, asArray(statsValues)));
+    }
+
+    private String[] asArray(Collection<String> elements) {
+        return elements.stream().toArray(String[]::new);
     }
 
     private List<AnnotationDocument> createGenericDocs(int n) {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsResponseVerifier.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsResponseVerifier.java
@@ -14,7 +14,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 final class StatsResponseVerifier {
     private static final String GROUP_NAME_TAG = "groupName";
     private static final String TYPE_NAME_TAG = "type";
-    private static final String VALUE_NAME_TAG = "values";
     private static final String KEY_NAME_TAG = "key";
     private static final String TOTAL_GROUP_HITS_TAG = "totalHits";
 
@@ -26,6 +25,27 @@ final class StatsResponseVerifier {
         return jsonPath(
                 format(hitsInGroupText, ResponseVerifier.RESULTS, GROUP_NAME_TAG, groupName, TOTAL_GROUP_HITS_TAG)
         ).value(hits);
+    }
+
+    /**
+     * Checks that the value specified in the {@param value} is present in the {@param
+     * type} within the given {@param group}.
+     *
+     * @param group the stats group to check in
+     * @param type the stats type defined within in the {@param group}
+     * @param value the value to check for
+     * @return a {@link ResultMatcher} that checks for the given inputs
+     */
+    static ResultMatcher numericValueForGroup(String group, String type, String field, int value) {
+        String valuesInTypeForGroup = "%s[?(@.%s=='%s')]..[?(@.%s=='%s')]..%s";
+        return jsonPath(
+                format(valuesInTypeForGroup,
+                        ResponseVerifier.RESULTS,
+                        GROUP_NAME_TAG, group,
+                        TYPE_NAME_TAG, type,
+                        field),
+                containsInAnyOrder(value)
+        );
     }
 
     /**

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
@@ -67,22 +67,30 @@ public class StatisticsByTypeTest {
         String type = "type";
         StatisticsByType statsType = new StatisticsByType(type, 11999);
 
-        assertThat(statsType.getDistinctValueCount(), is(11000));
+        assertThat(statsType.getDistinctValueCount(), is(12000));
     }
 
     @Test
-    public void addedStatisticsValueRoundedIfValueGreaterThan100K() {
+    public void roundUpDistinctCount() {
         String type = "type";
         StatisticsByType statsType = new StatisticsByType(type, 487934);
 
-        assertThat(statsType.getDistinctValueCount(), is(487000));
+        assertThat(statsType.getDistinctValueCount(), is(488000));
     }
 
     @Test
-    public void addedStatisticsValueRoundedIfValueGreaterThan1m() {
+    public void noNeedToRoundUpDistinctCount() {
+        String type = "type";
+        StatisticsByType statsType = new StatisticsByType(type, 333434);
+
+        assertThat(statsType.getDistinctValueCount(), is(333000));
+    }
+
+    @Test
+    public void distinctCountGreaterThan1m() {
         String type = "type";
         StatisticsByType statsType = new StatisticsByType(type, 7487934);
 
-        assertThat(statsType.getDistinctValueCount(), is(7487000));
+        assertThat(statsType.getDistinctValueCount(), is(7488000));
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
@@ -50,12 +50,40 @@ public class StatisticsByTypeTest {
     @Test
     public void addedStatisticsValueIsRetrievedCorrectly() {
         String type = "type";
-        StatisticsValue value = new StatisticsValue("key", 0, 0);
-
         StatisticsByType statsType = new StatisticsByType(type,12);
-        statsType.addValue(value);
 
-        assertThat(statsType.getValues(), contains(value));
         assertThat(statsType.getDistinctValueCount(), is(12));
+    }
+
+    @Test
+    public void addedStatisticsValueRoundedIfValueGreaterThan10K() {
+        String type = "type";
+        StatisticsByType statsType = new StatisticsByType(type, 10001);
+
+        assertThat(statsType.getDistinctValueCount(), is(10000));
+    }
+
+    @Test
+    public void addedStatisticsValueRoundedIfValueGreaterThan10KTest2() {
+        String type = "type";
+        StatisticsByType statsType = new StatisticsByType(type, 11999);
+
+        assertThat(statsType.getDistinctValueCount(), is(11000));
+    }
+
+    @Test
+    public void addedStatisticsValueRoundedIfValueGreaterThan100K() {
+        String type = "type";
+        StatisticsByType statsType = new StatisticsByType(type, 487934);
+
+        assertThat(statsType.getDistinctValueCount(), is(487000));
+    }
+
+    @Test
+    public void addedStatisticsValueRoundedIfValueGreaterThan1m() {
+        String type = "type";
+        StatisticsByType statsType = new StatisticsByType(type, 7487934);
+
+        assertThat(statsType.getDistinctValueCount(), is(7487000));
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
@@ -6,6 +6,7 @@ import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Tests the behaviour of the {@link StatisticsByType} class.
@@ -21,7 +22,7 @@ public class StatisticsByTypeTest {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Statistics type cannot be null or empty");
 
-        new StatisticsByType(type);
+        new StatisticsByType(type,0);
     }
 
     @Test
@@ -31,7 +32,7 @@ public class StatisticsByTypeTest {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Statistics type cannot be null or empty");
 
-        new StatisticsByType(type);
+        new StatisticsByType(type,0);
     }
 
     @Test
@@ -42,7 +43,7 @@ public class StatisticsByTypeTest {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Stats value cannot be null");
 
-        StatisticsByType statsType = new StatisticsByType(type);
+        StatisticsByType statsType = new StatisticsByType(type,0);
         statsType.addValue(value);
     }
 
@@ -51,9 +52,10 @@ public class StatisticsByTypeTest {
         String type = "type";
         StatisticsValue value = new StatisticsValue("key", 0, 0);
 
-        StatisticsByType statsType = new StatisticsByType(type);
+        StatisticsByType statsType = new StatisticsByType(type,12);
         statsType.addValue(value);
 
         assertThat(statsType.getValues(), contains(value));
+        assertThat(statsType.getDistinctValueCount(), is(12));
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -22,7 +21,7 @@ public class StatisticsByTypeTest {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Statistics type cannot be null or empty");
 
-        new StatisticsByType(type,0);
+        new StatisticsByType(type, 0);
     }
 
     @Test
@@ -32,7 +31,7 @@ public class StatisticsByTypeTest {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Statistics type cannot be null or empty");
 
-        new StatisticsByType(type,0);
+        new StatisticsByType(type, 0);
     }
 
     @Test
@@ -43,14 +42,14 @@ public class StatisticsByTypeTest {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Stats value cannot be null");
 
-        StatisticsByType statsType = new StatisticsByType(type,0);
+        StatisticsByType statsType = new StatisticsByType(type, 0);
         statsType.addValue(value);
     }
 
     @Test
     public void addedStatisticsValueIsRetrievedCorrectly() {
         String type = "type";
-        StatisticsByType statsType = new StatisticsByType(type,12);
+        StatisticsByType statsType = new StatisticsByType(type, 12);
 
         assertThat(statsType.getDistinctValueCount(), is(12));
     }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
@@ -35,6 +35,16 @@ public class StatisticsByTypeTest {
     }
 
     @Test
+    public void negativeDistinctValueCountThrowsException() {
+        String type = "type";
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Distinct Value Count should be be greater than zero.");
+
+        new StatisticsByType(type, -10);
+    }
+
+    @Test
     public void nullStatisticsValueThrowsException() {
         String type = "type";
         StatisticsValue value = null;
@@ -47,15 +57,23 @@ public class StatisticsByTypeTest {
     }
 
     @Test
-    public void addedStatisticsValueIsRetrievedCorrectly() {
+    public void zeroDistinctValueCountIsOK() {
         String type = "type";
-        StatisticsByType statsType = new StatisticsByType(type, 12);
+        StatisticsByType statsType = new StatisticsByType(type, 0);
 
-        assertThat(statsType.getDistinctValueCount(), is(12));
+        assertThat(statsType.getDistinctValueCount(), is(0));
     }
 
     @Test
-    public void addedStatisticsValueRoundedIfValueGreaterThan10K() {
+    public void distinctValueCountBelow10001IsUnchanged() {
+        String type = "type";
+        StatisticsByType statsType = new StatisticsByType(type, 10000);
+
+        assertThat(statsType.getDistinctValueCount(), is(10000));
+    }
+
+    @Test
+    public void distinctValueCountRoundedDownIfValueGreaterThan10KAndEndsWith101To499() {
         String type = "type";
         StatisticsByType statsType = new StatisticsByType(type, 10001);
 
@@ -63,34 +81,18 @@ public class StatisticsByTypeTest {
     }
 
     @Test
-    public void addedStatisticsValueRoundedIfValueGreaterThan10KTest2() {
+    public void distinctValueCountRoundedDownIfEndsWith499OrLess() {
         String type = "type";
-        StatisticsByType statsType = new StatisticsByType(type, 11999);
+        StatisticsByType statsType = new StatisticsByType(type, 10499);
 
-        assertThat(statsType.getDistinctValueCount(), is(12000));
+        assertThat(statsType.getDistinctValueCount(), is(10000));
     }
 
     @Test
-    public void roundUpDistinctCount() {
+    public void distinctValueCountRoundedUpIfEndsWith500OrGreater() {
         String type = "type";
-        StatisticsByType statsType = new StatisticsByType(type, 487934);
+        StatisticsByType statsType = new StatisticsByType(type, 10500);
 
-        assertThat(statsType.getDistinctValueCount(), is(488000));
-    }
-
-    @Test
-    public void noNeedToRoundUpDistinctCount() {
-        String type = "type";
-        StatisticsByType statsType = new StatisticsByType(type, 333434);
-
-        assertThat(statsType.getDistinctValueCount(), is(333000));
-    }
-
-    @Test
-    public void distinctCountGreaterThan1m() {
-        String type = "type";
-        StatisticsByType statsType = new StatisticsByType(type, 7487934);
-
-        assertThat(statsType.getDistinctValueCount(), is(7488000));
+        assertThat(statsType.getDistinctValueCount(), is(11000));
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsGroupTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsGroupTest.java
@@ -66,7 +66,7 @@ public class StatisticsGroupTest {
         String groupName = "group";
         int totalHits = 0;
 
-        StatisticsByType statsType = new StatisticsByType("type",0);
+        StatisticsByType statsType = new StatisticsByType("type", 0);
 
         StatisticsGroup statsGroup = new StatisticsGroup(groupName, totalHits);
         statsGroup.addStatsType(statsType);

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsGroupTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsGroupTest.java
@@ -66,7 +66,7 @@ public class StatisticsGroupTest {
         String groupName = "group";
         int totalHits = 0;
 
-        StatisticsByType statsType = new StatisticsByType("type");
+        StatisticsByType statsType = new StatisticsByType("type",0);
 
         StatisticsGroup statsGroup = new StatisticsGroup(groupName, totalHits);
         statsGroup.addStatsType(statsType);

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/converter/WorkbookFromStatisticsImplTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/converter/WorkbookFromStatisticsImplTest.java
@@ -24,17 +24,16 @@ import static uk.ac.ebi.quickgo.annotation.service.converter.WorkbookFromStatist
  * Created with IntelliJ IDEA.
  */
 public class WorkbookFromStatisticsImplTest {
-    private List<StatisticsGroup> statisticsGroups;
     private static final Map<String, WorkbookFromStatisticsImpl.SheetLayout> SHEET_LAYOUT_MAP = new HashMap<>();
     private static final StatisticsWorkBookLayout.AnnotationSectionLayout SL_ANNOTATION_GOID =
             new StatisticsWorkBookLayout.AnnotationSectionLayout("GO IDs (by annotation)");
     private static final StatisticsWorkBookLayout.AnnotationSectionLayout SL_ANNOTATION_ASPECT =
             new StatisticsWorkBookLayout.AnnotationSectionLayout("Aspects (by annotation)");
-
     private static final StatisticsWorkBookLayout.GeneProductSectionLayout SL_GENE_PRODUCT_GOID =
             new StatisticsWorkBookLayout.GeneProductSectionLayout("GO IDs (by protein)");
     private static final StatisticsWorkBookLayout.GeneProductSectionLayout SL_GENE_PRODUCT_ASPECT =
             new StatisticsWorkBookLayout.GeneProductSectionLayout("Aspects (by protein)");
+
     static {
         SHEET_LAYOUT_MAP.put("TEST_GO_ID",
                 new WorkbookFromStatisticsImpl.SheetLayout("goid",
@@ -47,15 +46,17 @@ public class WorkbookFromStatisticsImplTest {
                                 SL_GENE_PRODUCT_ASPECT)));
     }
 
+    private List<StatisticsGroup> statisticsGroups;
 
     @Before
-    public void setup(){
+    public void setup() {
         buildStatisticGroups();
     }
 
     @Test
-    public void workbookMatchesInputData(){
-        WorkbookFromStatisticsImpl statisticsToWorkbook = new WorkbookFromStatisticsImpl(SECTION_TYPES, SHEET_LAYOUT_MAP);
+    public void workbookMatchesInputData() {
+        WorkbookFromStatisticsImpl statisticsToWorkbook =
+                new WorkbookFromStatisticsImpl(SECTION_TYPES, SHEET_LAYOUT_MAP);
 
         Workbook workbook = statisticsToWorkbook.generate(statisticsGroups);
 
@@ -69,7 +70,6 @@ public class WorkbookFromStatisticsImplTest {
         assertThat(workbook.getSheetAt(0).getRow(3).getCell(0).getStringCellValue(),
                 is(GENE_PRODUCTS_SUMMARY + "1"));
 
-
         assertThat(workbook.getSheetAt(1).getSheetName(), is("goid"));
         assertThat(workbook.getSheetAt(1).getPhysicalNumberOfRows(), is(5));
 
@@ -78,30 +78,29 @@ public class WorkbookFromStatisticsImplTest {
 
         // test goID sheet contents
         //by annotation
-        assertThat(workbook.getSheetAt(1).getRow(3).getCell(0).getStringCellValue(),is("GO:0003824"));
-        assertThat(workbook.getSheetAt(1).getRow(3).getCell(2).getNumericCellValue(),is(20.00d));
-        assertThat(workbook.getSheetAt(1).getRow(3).getCell(3).getNumericCellValue(),is(1d));
-        assertThat(workbook.getSheetAt(1).getRow(5).getCell(0).getStringCellValue(),is("GO:0009058"));
-        assertThat(workbook.getSheetAt(1).getRow(5).getCell(2).getNumericCellValue(),is(20.00d));
-        assertThat(workbook.getSheetAt(1).getRow(5).getCell(3).getNumericCellValue(),is(1d));
+        assertThat(workbook.getSheetAt(1).getRow(3).getCell(0).getStringCellValue(), is("GO:0003824"));
+        assertThat(workbook.getSheetAt(1).getRow(3).getCell(2).getNumericCellValue(), is(20.00d));
+        assertThat(workbook.getSheetAt(1).getRow(3).getCell(3).getNumericCellValue(), is(1d));
+        assertThat(workbook.getSheetAt(1).getRow(5).getCell(0).getStringCellValue(), is("GO:0009058"));
+        assertThat(workbook.getSheetAt(1).getRow(5).getCell(2).getNumericCellValue(), is(20.00d));
+        assertThat(workbook.getSheetAt(1).getRow(5).getCell(3).getNumericCellValue(), is(1d));
 
         //by gene product
-        assertThat(workbook.getSheetAt(1).getRow(5).getCell(10).getStringCellValue(),is("GO:0009058"));
-        assertThat(workbook.getSheetAt(1).getRow(5).getCell(12).getNumericCellValue(),is(100.00d));
-        assertThat(workbook.getSheetAt(1).getRow(5).getCell(13).getNumericCellValue(),is(1d));
+        assertThat(workbook.getSheetAt(1).getRow(5).getCell(10).getStringCellValue(), is("GO:0009058"));
+        assertThat(workbook.getSheetAt(1).getRow(5).getCell(12).getNumericCellValue(), is(100.00d));
+        assertThat(workbook.getSheetAt(1).getRow(5).getCell(13).getNumericCellValue(), is(1d));
 
         //Check some details for the aspect sheet.
         assertThat(workbook.getSheetAt(2).getSheetName(), is("aspect"));
         assertThat(workbook.getSheetAt(2).getPhysicalNumberOfRows(), is(4));
     }
 
-
-    @Test (expected = IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void creatingStatisticsToWorkbookWithNullSectionTypesThrowsException() {
         new WorkbookFromStatisticsImpl(null, SHEET_LAYOUT_MAP);
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void creatingStatisticsToWorkbookWithNullLayoutMapThrowsException() {
         new WorkbookFromStatisticsImpl(SECTION_TYPES, null);
     }
@@ -121,27 +120,27 @@ public class WorkbookFromStatisticsImplTest {
         statisticsGroups.add(geneProductStatisticsGroup);
 
         //GoId
-        StatisticsByType statisticsByAnnotationTypeGoId = new StatisticsByType("TEST_GO_ID",0);
+        StatisticsByType statisticsByAnnotationTypeGoId = new StatisticsByType("TEST_GO_ID", 0);
         statisticsByAnnotationTypeGoId.addValue(new StatisticsValue("GO:0003824", 1, 5L));
-        statisticsByAnnotationTypeGoId.addValue(new StatisticsValue("GO:0003870",1, 5L));
-        statisticsByAnnotationTypeGoId.addValue(new StatisticsValue("GO:0009058",1, 5L));
+        statisticsByAnnotationTypeGoId.addValue(new StatisticsValue("GO:0003870", 1, 5L));
+        statisticsByAnnotationTypeGoId.addValue(new StatisticsValue("GO:0009058", 1, 5L));
         annotationStatisticsGroup.addStatsType(statisticsByAnnotationTypeGoId);
 
-        StatisticsByType statisticsByGeneProductTypeGoId = new StatisticsByType("TEST_GO_ID",0);
-        statisticsByGeneProductTypeGoId.addValue(new StatisticsValue("GO:0003824",1, 1L));
-        statisticsByGeneProductTypeGoId.addValue(new StatisticsValue("GO:0003870",1, 1L));
-        statisticsByGeneProductTypeGoId.addValue(new StatisticsValue("GO:0009058",1, 1L));
+        StatisticsByType statisticsByGeneProductTypeGoId = new StatisticsByType("TEST_GO_ID", 0);
+        statisticsByGeneProductTypeGoId.addValue(new StatisticsValue("GO:0003824", 1, 1L));
+        statisticsByGeneProductTypeGoId.addValue(new StatisticsValue("GO:0003870", 1, 1L));
+        statisticsByGeneProductTypeGoId.addValue(new StatisticsValue("GO:0009058", 1, 1L));
         geneProductStatisticsGroup.addStatsType(statisticsByGeneProductTypeGoId);
 
         //aspect
-        StatisticsByType statisticsByAnnotationTypeAspect = new StatisticsByType("aspect",0);
-        statisticsByAnnotationTypeAspect.addValue(new StatisticsValue("molecular_function",3, 5L));
-        statisticsByAnnotationTypeAspect.addValue(new StatisticsValue("biological_process",2, 5L));
+        StatisticsByType statisticsByAnnotationTypeAspect = new StatisticsByType("aspect", 0);
+        statisticsByAnnotationTypeAspect.addValue(new StatisticsValue("molecular_function", 3, 5L));
+        statisticsByAnnotationTypeAspect.addValue(new StatisticsValue("biological_process", 2, 5L));
         annotationStatisticsGroup.addStatsType(statisticsByAnnotationTypeAspect);
 
-        StatisticsByType statisticsByGeneProductTypeAspect = new StatisticsByType("aspect",0);
-        statisticsByGeneProductTypeAspect.addValue(new StatisticsValue("molecular_function",1, 1L));
-        statisticsByGeneProductTypeAspect.addValue(new StatisticsValue("biological_process",1, 1L));
+        StatisticsByType statisticsByGeneProductTypeAspect = new StatisticsByType("aspect", 0);
+        statisticsByGeneProductTypeAspect.addValue(new StatisticsValue("molecular_function", 1, 1L));
+        statisticsByGeneProductTypeAspect.addValue(new StatisticsValue("biological_process", 1, 1L));
         geneProductStatisticsGroup.addStatsType(statisticsByGeneProductTypeAspect);
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/converter/WorkbookFromStatisticsImplTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/converter/WorkbookFromStatisticsImplTest.java
@@ -121,25 +121,25 @@ public class WorkbookFromStatisticsImplTest {
         statisticsGroups.add(geneProductStatisticsGroup);
 
         //GoId
-        StatisticsByType statisticsByAnnotationTypeGoId = new StatisticsByType("TEST_GO_ID");
+        StatisticsByType statisticsByAnnotationTypeGoId = new StatisticsByType("TEST_GO_ID",0);
         statisticsByAnnotationTypeGoId.addValue(new StatisticsValue("GO:0003824", 1, 5L));
         statisticsByAnnotationTypeGoId.addValue(new StatisticsValue("GO:0003870",1, 5L));
         statisticsByAnnotationTypeGoId.addValue(new StatisticsValue("GO:0009058",1, 5L));
         annotationStatisticsGroup.addStatsType(statisticsByAnnotationTypeGoId);
 
-        StatisticsByType statisticsByGeneProductTypeGoId = new StatisticsByType("TEST_GO_ID");
+        StatisticsByType statisticsByGeneProductTypeGoId = new StatisticsByType("TEST_GO_ID",0);
         statisticsByGeneProductTypeGoId.addValue(new StatisticsValue("GO:0003824",1, 1L));
         statisticsByGeneProductTypeGoId.addValue(new StatisticsValue("GO:0003870",1, 1L));
         statisticsByGeneProductTypeGoId.addValue(new StatisticsValue("GO:0009058",1, 1L));
         geneProductStatisticsGroup.addStatsType(statisticsByGeneProductTypeGoId);
 
         //aspect
-        StatisticsByType statisticsByAnnotationTypeAspect = new StatisticsByType("aspect");
+        StatisticsByType statisticsByAnnotationTypeAspect = new StatisticsByType("aspect",0);
         statisticsByAnnotationTypeAspect.addValue(new StatisticsValue("molecular_function",3, 5L));
         statisticsByAnnotationTypeAspect.addValue(new StatisticsValue("biological_process",2, 5L));
         annotationStatisticsGroup.addStatsType(statisticsByAnnotationTypeAspect);
 
-        StatisticsByType statisticsByGeneProductTypeAspect = new StatisticsByType("aspect");
+        StatisticsByType statisticsByGeneProductTypeAspect = new StatisticsByType("aspect",0);
         statisticsByGeneProductTypeAspect.addValue(new StatisticsValue("molecular_function",1, 1L));
         statisticsByGeneProductTypeAspect.addValue(new StatisticsValue("biological_process",1, 1L));
         geneProductStatisticsGroup.addStatsType(statisticsByGeneProductTypeAspect);

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponse.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponse.java
@@ -72,8 +72,8 @@ public class AggregateResponse {
     private final Set<AggregationBucket> buckets;
     private int distinctValuesCount;
 
-    public AggregateResponse(String name, AggregationResultsManager aggregationResultsManager, Set
-            nestedAggregations, Set buckets, int distinctValuesCount) {
+    public AggregateResponse(String name, AggregationResultsManager aggregationResultsManager, Set<AggregateResponse>
+            nestedAggregations, Set<AggregationBucket> buckets, int distinctValuesCount) {
         Preconditions.checkArgument(name != null && !name.trim().isEmpty(), "Name cannot be null or empty");
         Preconditions.checkArgument(aggregationResultsManager != null, "Aggregation Results Manager cannot be null");
         Preconditions.checkArgument(nestedAggregations != null && !name.trim().isEmpty(), "Nested Aggregations " +
@@ -134,7 +134,7 @@ public class AggregateResponse {
      * Indicates whether the aggregation has nested aggregations stored within it.
      * @return true if there are nested aggregations associated to this aggregation, false otherwise.
      */
-    public boolean hasNestedAggregations() {
+    boolean hasNestedAggregations() {
         return !nestedAggregations.isEmpty();
     }
 
@@ -151,7 +151,7 @@ public class AggregateResponse {
      * Indicates whether the aggregation, at the moment of the method call, has any buckets associated to it.
      * @return boolean indicating whether or not the aggregation has associated buckets
      */
-    public boolean hasBuckets() {
+    boolean hasBuckets() {
         return !buckets.isEmpty();
     }
 

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponse.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponse.java
@@ -23,6 +23,9 @@ import java.util.Set;
  *     <li>A set of {@link AggregateResponse#nestedAggregations}: A nested aggregation is a drilled down view of the main
  *     aggregation. This means that it tries to retrieve metrics on a different aggregate field, but always based on
  *     the result of the current aggregation</li>
+ *     <li>A distinct value count. The number of buckets contained in an instance of this class is constrained by
+ *     the limits applied at the time the aggregation was defined. This value holds the total number of distinct
+ *     values (i.e. the number of buckets there would be if no limits were applied)</li>
  * </ul>
  * <p/>
  * As an example, assume that the data source has a table/collection of orders, with the following fields:
@@ -50,6 +53,8 @@ import java.util.Set;
  *                - aggregationResults: [5] - where 5 represents the sum of the quantities for order_item_2
  *            ...
  *        ]
+ *       - distinctValueCount: the total number of order items (the results for the query may show only order items
+ *       only over a certain value, or goods type.
  * </pre>
  * <p/>
  * If {@link AggregateRequest} instances are attached to the
@@ -63,12 +68,12 @@ public class AggregateResponse {
     private final AggregationResultsManager aggregationResultsManager;
     private final Set<AggregateResponse> nestedAggregations;
     private final Set<AggregationBucket> buckets;
+    private int distinctValuesCount;
 
     public AggregateResponse(String name) {
         Preconditions.checkArgument(name != null && !name.trim().isEmpty(), "Name cannot be null or empty");
 
         this.name = name;
-
         this.aggregationResultsManager = new AggregationResultsManager();
         nestedAggregations = new LinkedHashSet<>();
         buckets = new LinkedHashSet<>();
@@ -190,5 +195,31 @@ public class AggregateResponse {
      */
     public boolean isPopulated() {
         return this.hasAggregationResults() || this.hasNestedAggregations() || this.hasBuckets();
+    }
+
+    /**
+     * Set the total number of distinct values for the aggregation.
+     * @param distinctValuesCount
+     */
+    public void setDistinctValuesCount(int distinctValuesCount) {
+        this.distinctValuesCount = distinctValuesCount;
+    }
+
+    /**
+     * Return the total number of distinct values for the aggregation.
+     * @return total number of distinct values
+     */
+    public int getDistinctValuesCount() {
+        return distinctValuesCount;
+    }
+
+    @Override public String toString() {
+        return "AggregateResponse{" +
+                "name='" + name + '\'' +
+                ", aggregationResultsManager=" + aggregationResultsManager +
+                ", nestedAggregations=" + nestedAggregations +
+                ", buckets=" + buckets +
+                ", distinctValuesCount=" + distinctValuesCount +
+                '}';
     }
 }

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponse.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponse.java
@@ -4,9 +4,10 @@ import uk.ac.ebi.quickgo.rest.search.AggregateFunction;
 import uk.ac.ebi.quickgo.rest.search.query.AggregateRequest;
 
 import com.google.common.base.Preconditions;
-import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
+
+import static java.util.Collections.unmodifiableSet;
 
 /**
  * Stores the result of the aggregation section found within the response of the underlying data source.
@@ -20,7 +21,8 @@ import java.util.Set;
  *     field that can be calculated within the response's ability, example: sum(field1) or unique(field2)</li>
  *     <li>A set of {@link AggregationBucket}: Each bucket represents a distinct value of the field being
  *     aggregated upon, as well as any {@link AggregationResult} applied to the bucket value</li>
- *     <li>A set of {@link AggregateResponse#nestedAggregations}: A nested aggregation is a drilled down view of the main
+ *     <li>A set of {@link AggregateResponse#nestedAggregations}: A nested aggregation is a drilled down view of the
+ *     main
  *     aggregation. This means that it tries to retrieve metrics on a different aggregate field, but always based on
  *     the result of the current aggregation</li>
  *     <li>A distinct value count. The number of buckets contained in an instance of this class is constrained by
@@ -70,46 +72,21 @@ public class AggregateResponse {
     private final Set<AggregationBucket> buckets;
     private int distinctValuesCount;
 
-    public AggregateResponse(String name) {
+    public AggregateResponse(String name, AggregationResultsManager aggregationResultsManager, Set
+            nestedAggregations, Set buckets, int distinctValuesCount) {
         Preconditions.checkArgument(name != null && !name.trim().isEmpty(), "Name cannot be null or empty");
+        Preconditions.checkArgument(aggregationResultsManager != null, "Aggregation Results Manager cannot be null");
+        Preconditions.checkArgument(nestedAggregations != null && !name.trim().isEmpty(), "Nested Aggregations " +
+                "cannot be null");
+        Preconditions.checkArgument(buckets != null && !name.trim().isEmpty(), "Buckets " +
+                "cannot be null");
+        Preconditions.checkArgument(distinctValuesCount >= 0, "DistinctValueCount must be zero or greater");
 
         this.name = name;
-        this.aggregationResultsManager = new AggregationResultsManager();
-        nestedAggregations = new LinkedHashSet<>();
-        buckets = new LinkedHashSet<>();
-    }
-
-    /**
-     * Adds the result of the application of an aggregation function over a given field.
-     *
-     * @param function the aggregation function that was applied
-     * @param field the field the function was applied over
-     * @param result the result of the application of the function over the field
-     */
-    public void addAggregationResult(AggregateFunction function, String field, double result) {
-        aggregationResultsManager.addAggregateResult(function, field, result);
-    }
-
-    /**
-     * Adds a set of distinct values of a given field. The bucket can also potentially contain aggregation
-     * results.
-     *
-     * @param bucket a set of distinct results of field
-     */
-    public void addBucket(AggregationBucket bucket) {
-        Preconditions.checkArgument(bucket != null, "AggregationBucket cannot be null");
-        buckets.add(bucket);
-    }
-
-    /**
-     * Adds a lower level aggregation to the current one. Usually nested aggregations are drilled down results
-     * applied to a different field than the current aggregation.
-     *
-     * @param aggregation an aggregation
-     */
-    public void addNestedAggregation(AggregateResponse aggregation) {
-        Preconditions.checkArgument(aggregation != null, "Nested aggregation cannot be null");
-        nestedAggregations.add(aggregation);
+        this.aggregationResultsManager = aggregationResultsManager;
+        this.nestedAggregations = nestedAggregations;
+        this.buckets = buckets;
+        this.distinctValuesCount = distinctValuesCount;
     }
 
     /**
@@ -127,19 +104,10 @@ public class AggregateResponse {
     /**
      * Returns all the results of aggregation functions applied on fields.
      *
-     * @return a set of {@link AggregationResult}s.
+     * @return a unmodifiable set of {@link AggregationResult}s.
      */
     public Set<AggregationResult> getAggregationResults() {
-        return aggregationResultsManager.getAggregationResults();
-    }
-
-    /**
-     * Checks if there are any aggregations results stored within the aggregation.
-     *
-     * @return true if there is at least one aggregation result, false otherwise.
-     */
-    public boolean hasAggregationResults() {
-        return !aggregationResultsManager.getAggregationResults().isEmpty();
+        return unmodifiableSet(aggregationResultsManager.getAggregationResults());
     }
 
     /**
@@ -156,10 +124,10 @@ public class AggregateResponse {
     /**
      * Returns a set of all nested aggregations.
      *
-     * @return a set of the nested aggregations.
+     * @return a unmodifiable set of the nested aggregations.
      */
     public Set<AggregateResponse> getNestedAggregations() {
-        return nestedAggregations;
+        return unmodifiableSet(nestedAggregations);
     }
 
     /**
@@ -173,10 +141,10 @@ public class AggregateResponse {
     /**
      * Returns the set of aggregation buckets associated to this aggregation.
      *
-     * @return a set of {@link AggregationBucket}
+     * @return a unmodifiable set of {@link AggregationBucket}
      */
     public Set<AggregationBucket> getBuckets() {
-        return buckets;
+        return unmodifiableSet(buckets);
     }
 
     /**
@@ -198,14 +166,6 @@ public class AggregateResponse {
     }
 
     /**
-     * Set the total number of distinct values for the aggregation.
-     * @param distinctValuesCount
-     */
-    public void setDistinctValuesCount(int distinctValuesCount) {
-        this.distinctValuesCount = distinctValuesCount;
-    }
-
-    /**
      * Return the total number of distinct values for the aggregation.
      * @return total number of distinct values
      */
@@ -221,5 +181,14 @@ public class AggregateResponse {
                 ", buckets=" + buckets +
                 ", distinctValuesCount=" + distinctValuesCount +
                 '}';
+    }
+
+    /**
+     * Checks if there are any aggregations results stored within the aggregation.
+     *
+     * @return true if there is at least one aggregation result, false otherwise.
+     */
+    boolean hasAggregationResults() {
+        return !aggregationResultsManager.getAggregationResults().isEmpty();
     }
 }

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponse.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponse.java
@@ -70,7 +70,7 @@ public class AggregateResponse {
     private final AggregationResultsManager aggregationResultsManager;
     private final Set<AggregateResponse> nestedAggregations;
     private final Set<AggregationBucket> buckets;
-    private int distinctValuesCount;
+    private final int distinctValuesCount;
 
     public AggregateResponse(String name, AggregationResultsManager aggregationResultsManager, Set<AggregateResponse>
             nestedAggregations, Set<AggregationBucket> buckets, int distinctValuesCount) {

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponseBuilder.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponseBuilder.java
@@ -1,0 +1,77 @@
+package uk.ac.ebi.quickgo.rest.search.results;
+
+import uk.ac.ebi.quickgo.rest.search.AggregateFunction;
+
+import com.google.common.base.Preconditions;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Builder for {@link AggregateResponse}
+ */
+
+public class AggregateResponseBuilder {
+    private String name;
+    private AggregationResultsManager aggregationResultsManager;
+    private final Set<AggregateResponse> nestedAggregations;
+    private final Set<AggregationBucket> buckets;
+    private int distinctValuesCount;
+
+    public AggregateResponseBuilder(String name) {
+        Preconditions.checkArgument(name != null && !name.trim().isEmpty(), "Name cannot be null or empty");
+
+        this.name = name;
+        this.aggregationResultsManager = new AggregationResultsManager();
+        nestedAggregations = new LinkedHashSet<>();
+        buckets = new LinkedHashSet<>();
+    }
+
+    /**
+     * Adds the result of the application of an aggregation function over a given field.
+     *
+     * @param function the aggregation function that was applied
+     * @param field the field the function was applied over
+     * @param result the result of the application of the function over the field
+     */
+    public void addAggregationResult(AggregateFunction function, String field, double result) {
+        aggregationResultsManager.addAggregateResult(function, field, result);
+    }
+
+    /**
+     * Adds a set of distinct values of a given field. The bucket can also potentially contain aggregation
+     * results.
+     *
+     * @param bucket a set of distinct results of field
+     */
+    public void addBucket(AggregationBucket bucket) {
+        Preconditions.checkArgument(bucket != null, "AggregationBucket cannot be null");
+        buckets.add(bucket);
+    }
+
+    /**
+     * Adds a lower level aggregation to the current one. Usually nested aggregations are drilled down results
+     * applied to a different field than the current aggregation.
+     *
+     * @param aggregation an aggregation
+     */
+    public void addNestedAggregation(AggregateResponse aggregation) {
+        Preconditions.checkArgument(aggregation != null, "Nested aggregation cannot be null");
+        nestedAggregations.add(aggregation);
+    }
+
+    /**
+     * Set the total number of distinct values for the aggregation.
+     * @param distinctValuesCount calculated number of values of that type
+     */
+    public void setDistinctValuesCount(int distinctValuesCount) {
+        this.distinctValuesCount = distinctValuesCount;
+    }
+
+    /**
+     * Create an {@link AggregateResponse} instance from this class
+     * @return AggregateResponse instance.
+     */
+    public AggregateResponse createAggregateResponse() {
+        return new AggregateResponse(name, aggregationResultsManager, nestedAggregations, buckets, distinctValuesCount);
+    }
+}

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/AggregateToStringConverter.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/AggregateToStringConverter.java
@@ -29,6 +29,8 @@ public class AggregateToStringConverter implements AggregateConverter<String> {
     private static final String FACET_TYPE_FORMAT = "type" + NAME_TO_VALUE_SEPARATOR + "%s";
     private static final String FACET_FIELD_FORMAT = "field" + NAME_TO_VALUE_SEPARATOR + "%s";
     private static final String LIMIT_FIELD_FORMAT = "limit" + NAME_TO_VALUE_SEPARATOR + "%s";
+    static final String NUM_BUCKETS = "numBuckets";
+    static final String NUM_BUCKETS_TRUE = NUM_BUCKETS + ":true";
 
     @Override public String convert(AggregateRequest aggregate) {
         Preconditions.checkArgument(aggregate != null, "AggregateRequest to convert cannot be null");
@@ -175,8 +177,9 @@ public class AggregateToStringConverter implements AggregateConverter<String> {
 
         StringJoiner subFacetComponents = new StringJoiner(DECLARATION_SEPARATOR);
         subFacetComponents.add(createFacetType(FACET_TYPE_TERM))
-                .add(createFacetField(nestedAggregate.getName()));
-        subFacetComponents.add(createLimitField(nestedAggregate.getLimit()));
+                .add(NUM_BUCKETS_TRUE)
+                .add(createFacetField(nestedAggregate.getName()))
+                .add(createLimitField(nestedAggregate.getLimit()));
 
         if (!fields.isEmpty()) {
             subFacetComponents.add(FACET_MARKER + NAME_TO_VALUE_SEPARATOR + convert(nestedAggregate));

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/SolrAggregationHelper.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/SolrAggregationHelper.java
@@ -78,7 +78,7 @@ class SolrAggregationHelper {
      * @param field element of the aggregation result
      * @return true if field holds distinct value count field definition.
      */
-    static boolean distinctValueCountTester(String field) {
+    static boolean isDistinctValueCount(String field) {
         return NUM_BUCKETS.equals(field);
     }
 }

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/SolrAggregationHelper.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/SolrAggregationHelper.java
@@ -4,6 +4,8 @@ import uk.ac.ebi.quickgo.rest.search.AggregateFunction;
 
 import com.google.common.base.Preconditions;
 
+import static uk.ac.ebi.quickgo.rest.search.solr.AggregateToStringConverter.NUM_BUCKETS;
+
 /**
  * Defines a set of constants and utility methods to aid in the processing of aggregation requests and results from
  * Solr to the domain model, and vice versa.
@@ -69,5 +71,14 @@ class SolrAggregationHelper {
         }
 
         return fieldName;
+    }
+
+    /**
+     * Test the field to see if holds the result of the distinct value count.
+     * @param field element of the aggregation result
+     * @return true if field holds distinct value count field definition.
+     */
+    static boolean distinctValueCountTester(String field) {
+        return NUM_BUCKETS.equals(field);
     }
 }

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/SolrResponseAggregationConverter.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/SolrResponseAggregationConverter.java
@@ -28,6 +28,7 @@ import static uk.ac.ebi.quickgo.rest.search.solr.SolrAggregationHelper.*;
  *  unique_id=3,
  *  unique_geneProductId=3,
  *  agg_goId={
+ *    numBuckets: 11
  *    buckets=[
  *      {
  *        val=GO:0003824,
@@ -38,6 +39,7 @@ import static uk.ac.ebi.quickgo.rest.search.solr.SolrAggregationHelper.*;
  *    ]
  *  },
  *  agg_ecoId={
+ *    numBuckets: 20
  *    buckets=[
  *      {
  *        val=ECO:0000256,
@@ -112,7 +114,6 @@ public class SolrResponseAggregationConverter implements AggregationConverter<So
 
         if (!fieldPrefix.isEmpty()) {
             String name = SolrAggregationHelper.fieldNameExtractor(field);
-
             if (isNestedAggregate(fieldPrefix)) {
                 AggregateResponse nestedAggregation = createNestedAggregation(name, value);
                 aggregation.addNestedAggregation(nestedAggregation);
@@ -121,6 +122,9 @@ public class SolrResponseAggregationConverter implements AggregationConverter<So
             } else {
                 logger.debug("Unable to process field:{}, with prefix:{}", field, fieldPrefix);
             }
+        } else if (SolrAggregationHelper.distinctValueCountTester(field)){
+            aggregation.setDistinctValuesCount(((Number)value).intValue());
+
         } else if (isFieldBucket(field)) {
             List<NamedList<?>> buckets = (List<NamedList<?>>) value;
             buckets.forEach(bucket -> convertBucket((NamedList<?>) bucket, aggregation));

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/SolrResponseAggregationConverter.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/solr/SolrResponseAggregationConverter.java
@@ -122,12 +122,12 @@ public class SolrResponseAggregationConverter implements AggregationConverter<So
             } else {
                 logger.debug("Unable to process field:{}, with prefix:{}", field, fieldPrefix);
             }
-        } else if (SolrAggregationHelper.distinctValueCountTester(field)){
+        } else if (isDistinctValueCount(field)) {
             aggregation.setDistinctValuesCount(((Number)value).intValue());
 
         } else if (isFieldBucket(field)) {
             List<NamedList<?>> buckets = (List<NamedList<?>>) value;
-            buckets.forEach(bucket -> convertBucket((NamedList<?>) bucket, aggregation));
+            buckets.forEach(bucket -> convertBucket(bucket, aggregation));
         } else {
             logger.debug("Did not process field: {} with value: {}", field, value);
         }

--- a/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponseBuilderTest.java
+++ b/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponseBuilderTest.java
@@ -32,7 +32,7 @@ public class AggregateResponseBuilderTest {
     public void setUp() throws Exception {
         aggregateResponseBuilder = new AggregateResponseBuilder("agg");
         nestedAggregation = new AggregateResponse("nestedAggregation", new AggregationResultsManager(),
-                new LinkedHashSet(), new LinkedHashSet(), 5);
+                new LinkedHashSet<>(), new LinkedHashSet<>(), 5);
     }
 
     @Test

--- a/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponseBuilderTest.java
+++ b/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponseBuilderTest.java
@@ -1,0 +1,157 @@
+package uk.ac.ebi.quickgo.rest.search.results;
+
+import uk.ac.ebi.quickgo.rest.search.AggregateFunction;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * @author Tony Wardell
+ * Date: 24/11/2017
+ * Time: 15:27
+ * Created with IntelliJ IDEA.
+ */
+public class AggregateResponseBuilderTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private AggregateResponseBuilder aggregateResponseBuilder;
+    private AggregateResponse nestedAggregation;
+
+    @Before
+    public void setUp() throws Exception {
+        aggregateResponseBuilder = new AggregateResponseBuilder("agg");
+        nestedAggregation = new AggregateResponse("nestedAggregation", new AggregationResultsManager(),
+                new LinkedHashSet(), new LinkedHashSet(), 5);
+    }
+
+    @Test
+    public void nullNameInConstructorThrowsException() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Name cannot be null or empty");
+
+        new AggregateResponseBuilder(null);
+    }
+
+    @Test
+    public void emptyNameInConstructorThrowsException() throws Exception {
+        String name = "";
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Name cannot be null or empty");
+
+        new AggregateResponseBuilder(name);
+    }
+
+    @Test
+    public void addingNullBucketThrowsException() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("AggregationBucket cannot be null");
+
+        aggregateResponseBuilder.addBucket(null);
+    }
+
+    @Test
+    public void bucketGetsAddedToStoredBuckets() throws Exception {
+        AggregationBucket bucket = new AggregationBucket("value");
+
+        aggregateResponseBuilder.addBucket(bucket);
+
+        Set<AggregationBucket> retrievedBuckets = aggregateResponseBuilder.createAggregateResponse().getBuckets();
+
+        assertThat(retrievedBuckets, hasSize(1));
+        assertThat(retrievedBuckets, contains(bucket));
+    }
+
+    @Test
+    public void addingNullNestedAggregateThrowsException() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Nested aggregation cannot be null");
+
+        aggregateResponseBuilder.addNestedAggregation(null);
+    }
+
+    @Test
+    public void nestedAggregateGetsAddedToStoredAggregates() throws Exception {
+        aggregateResponseBuilder.addNestedAggregation(nestedAggregation);
+
+        Set<AggregateResponse> retrievedAggregates =
+                aggregateResponseBuilder.createAggregateResponse().getNestedAggregations();
+
+        assertThat(retrievedAggregates, hasSize(1));
+        assertThat(retrievedAggregates, contains(nestedAggregation));
+    }
+
+    @Test
+    public void aggregationWithNoNestedAggregationsReturnsFalseWhenQueriedAboutThePresenceOfNestedAggregations()
+            throws Exception {
+        assertThat(aggregateResponseBuilder.createAggregateResponse().hasNestedAggregations(), is(false));
+    }
+
+    @Test
+    public void aggregationWithANestedAggregationsReturnsTrueWhenQueriedAboutThePresenceOfNestedAggregations()
+            throws Exception {
+        aggregateResponseBuilder.addNestedAggregation(nestedAggregation);
+
+        assertThat(aggregateResponseBuilder.createAggregateResponse().hasNestedAggregations(), is(true));
+    }
+
+    @Test
+    public void aggregationWithNoAggregationsResultsReturnsFalseWhenQueriedAboutThePresenceOfAggregationResults()
+            throws Exception {
+        assertThat(aggregateResponseBuilder.createAggregateResponse().hasAggregationResults(), is(false));
+    }
+
+    @Test
+    public void aggregationWithAnAggregationsResultsReturnsTrueWhenQueriedAboutThePresenceOfAggregationResults()
+            throws Exception {
+        aggregateResponseBuilder.addAggregationResult(AggregateFunction.COUNT, "field", 0);
+
+        assertThat(aggregateResponseBuilder.createAggregateResponse().hasAggregationResults(), is(true));
+    }
+
+    @Test
+    public void aggregationWithNoResultsOrNestedingsOrBucketsReturnsFalseWhenQueriedIfItsPopulated() throws Exception {
+        assertThat(aggregateResponseBuilder.createAggregateResponse().isPopulated(), is(false));
+    }
+
+    @Test
+    public void aggregationWithAResultAndNoNestingsAndNoBucketsReturnsTrueWhenQueriedIfItsPopulated() throws Exception {
+        aggregateResponseBuilder.addAggregationResult(AggregateFunction.COUNT, "field", 0);
+
+        assertThat(aggregateResponseBuilder.createAggregateResponse().isPopulated(), is(true));
+    }
+
+    @Test
+    public void aggregationWithANestingAndNoResultAndNoBucketsReturnsTrueWhenQueriedIfItsPopulated()
+            throws Exception {
+        aggregateResponseBuilder.addNestedAggregation(nestedAggregation);
+
+        assertThat(aggregateResponseBuilder.createAggregateResponse().isPopulated(), is(true));
+    }
+
+    @Test
+    public void aggregationWithABucketAndNoResultAndNoNestingsReturnsTrueWhenQueriedIfItsPopulated()
+            throws Exception {
+        AggregationBucket bucket = new AggregationBucket("value");
+        aggregateResponseBuilder.addBucket(bucket);
+
+        assertThat(aggregateResponseBuilder.createAggregateResponse().isPopulated(), is(true));
+    }
+
+    @Test
+    public void aggregationSetDistinctValueCount() {
+        aggregateResponseBuilder.setDistinctValuesCount(12);
+        assertThat(aggregateResponseBuilder.createAggregateResponse().getDistinctValuesCount(), is(12));
+    }
+}

--- a/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponseTest.java
+++ b/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponseTest.java
@@ -164,4 +164,10 @@ public class AggregateResponseTest {
 
         assertThat(aggregation.isPopulated(), is(true));
     }
+
+    @Test
+    public void aggregationSetDistinctValueCount(){
+        aggregation.setDistinctValuesCount(12);
+        assertThat(aggregation.getDistinctValuesCount(), is(12));
+    }
 }

--- a/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponseTest.java
+++ b/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponseTest.java
@@ -2,6 +2,7 @@ package uk.ac.ebi.quickgo.rest.search.results;
 
 import uk.ac.ebi.quickgo.rest.search.AggregateFunction;
 
+import java.util.LinkedHashSet;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,24 +20,32 @@ import static org.hamcrest.Matchers.hasSize;
  * Note: tests dealing with {@link AggregationResult} are tested in {@link AggregationResultsManager}.
  */
 public class AggregateResponseTest {
+    private final String name = "agg";
+    private static final int DISTINCT_VALUES_COUNT = 12;
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-
     private AggregateResponse aggregation;
+    private AggregationResultsManager aggregationResultsManager;
+    private Set<AggregateResponse> nestedAggregations;
+    private Set<AggregationBucket> buckets;
 
     @Before
     public void setUp() throws Exception {
-        aggregation = new AggregateResponse("agg");
+        aggregationResultsManager = new AggregationResultsManager();
+        nestedAggregations = new LinkedHashSet<>();
+        buckets = new LinkedHashSet<>();
+        aggregation =
+                new AggregateResponse(name, aggregationResultsManager, nestedAggregations, buckets,
+                        DISTINCT_VALUES_COUNT);
     }
 
     @Test
     public void nullNameInConstructorThrowsException() throws Exception {
-        String name = null;
 
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Name cannot be null or empty");
 
-        new AggregateResponse(name);
+        new AggregateResponse(null, aggregationResultsManager, nestedAggregations, buckets, 0);
     }
 
     @Test
@@ -46,30 +55,47 @@ public class AggregateResponseTest {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Name cannot be null or empty");
 
-        new AggregateResponse(name);
+        new AggregateResponse(name, aggregationResultsManager, nestedAggregations, buckets, 0);
+
     }
 
     @Test
-    public void addingNullBucketThrowsException() throws Exception {
-        AggregationBucket bucket = null;
+    public void nullAggregationResultsManagerInConstructorThrowsException() throws Exception {
+        aggregationResultsManager = null;
 
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("AggregationBucket cannot be null");
+        thrown.expectMessage("Aggregation Results Manager cannot be null");
 
-        aggregation.addBucket(bucket);
+        new AggregateResponse(name, aggregationResultsManager, nestedAggregations, buckets, 0);
     }
 
     @Test
-    public void bucketGetsAddedToStoredBuckets() throws Exception {
-        AggregationBucket bucket = new AggregationBucket("value");
+    public void nullNestedAggregationsInConstructorThrowsException() throws Exception {
+        nestedAggregations = null;
 
-        aggregation.addBucket(bucket);
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Nested Aggregations cannot be null");
 
-        Set<AggregationBucket> retrievedBuckets = aggregation.getBuckets();
-
-        assertThat(retrievedBuckets, hasSize(1));
-        assertThat(retrievedBuckets, contains(bucket));
+        new AggregateResponse(name, aggregationResultsManager, nestedAggregations, buckets, 0);
     }
+
+    @Test
+    public void nullBucketsInConstructorThrowsException() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Buckets cannot be null");
+
+        new AggregateResponse(name, aggregationResultsManager, nestedAggregations, null, 0);
+    }
+
+    @Test
+    public void negativeDistinctValueCountsInConstructorThrowsException() throws Exception {
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("DistinctValueCount must be zero or greater");
+
+        new AggregateResponse(name, aggregationResultsManager, nestedAggregations, buckets, -1);
+    }
+
 
     @Test
     public void aggregationWithNoBucketsReturnsFalseWhenQueriedAboutThePresenceOfBuckets() throws Exception {
@@ -79,26 +105,17 @@ public class AggregateResponseTest {
     @Test
     public void aggregationWithOneBucketReturnsTrueWhenQueriedAboutThePresenceOfBuckets() throws Exception {
         AggregationBucket bucket = new AggregationBucket("value");
-        aggregation.addBucket(bucket);
+        buckets.add(bucket);
 
         assertThat(aggregation.hasBuckets(), is(true));
     }
 
     @Test
-    public void addingNullNestedAggregateThrowsException() throws Exception {
-        AggregateResponse nestedAggregation = null;
-
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Nested aggregation cannot be null");
-
-        aggregation.addNestedAggregation(nestedAggregation);
-    }
-
-    @Test
     public void nestedAggregateGetsAddedToStoredAggregates() throws Exception {
-        AggregateResponse nestedAggregation = new AggregateResponse("nestedAggregation");
-
-        aggregation.addNestedAggregation(nestedAggregation);
+        AggregateResponse nestedAggregation =
+                new AggregateResponse("nestedAggregation", new AggregationResultsManager(),
+                        new LinkedHashSet(), new LinkedHashSet(), 5);
+        nestedAggregations.add(nestedAggregation);
 
         Set<AggregateResponse> retrievedAggregates = aggregation.getNestedAggregations();
 
@@ -115,8 +132,10 @@ public class AggregateResponseTest {
     @Test
     public void aggregationWithANestedAggregationsReturnsTrueWhenQueriedAboutThePresenceOfNestedAggregations()
             throws Exception {
-        AggregateResponse nestedAggregation = new AggregateResponse("nestedAggregation");
-        aggregation.addNestedAggregation(nestedAggregation);
+        AggregateResponse nestedAggregation =
+                new AggregateResponse("nestedAggregation", new AggregationResultsManager(),
+                        new LinkedHashSet(), new LinkedHashSet(), 5);
+        nestedAggregations.add(nestedAggregation);
 
         assertThat(aggregation.hasNestedAggregations(), is(true));
     }
@@ -130,44 +149,47 @@ public class AggregateResponseTest {
     @Test
     public void aggregationWithAnAggregationsResultsReturnsTrueWhenQueriedAboutThePresenceOfAggregationResults()
             throws Exception {
-        aggregation.addAggregationResult(AggregateFunction.COUNT, "field", 0);
+        aggregationResultsManager.addAggregateResult(AggregateFunction.COUNT, "field", 0);
 
         assertThat(aggregation.hasAggregationResults(), is(true));
     }
 
     @Test
-    public void aggregationWithNoResultsOrNestedingsOrBucketsReturnsFalseWhenQueriedIfItsPopulated() throws Exception {
+    public void aggregationWithNoResultsOrNestedResultsOrBucketsReturnsFalseWhenQueriedIfItsPopulated() throws
+                                                                                                        Exception {
         assertThat(aggregation.isPopulated(), is(false));
     }
 
     @Test
-    public void aggregationWithAResultAndNoNestingsAndNoBucketsReturnsTrueWhenQueriedIfItsPopulated() throws Exception {
-        aggregation.addAggregationResult(AggregateFunction.COUNT, "field", 0);
+    public void aggregationWithAResultAndNoNestedResultsAndNoBucketsReturnsTrueWhenQueriedIfItsPopulated() throws
+                                                                                                           Exception {
+        aggregationResultsManager.addAggregateResult(AggregateFunction.COUNT, "field", 0);
 
         assertThat(aggregation.isPopulated(), is(true));
     }
 
     @Test
-    public void aggregationWithANestingAndNoResultAndNoBucketsReturnsTrueWhenQueriedIfItsPopulated()
+    public void aggregationWithANestedResultAndNoResultAndNoBucketsReturnsTrueWhenQueriedIfItsPopulated()
             throws Exception {
-        AggregateResponse nestedAggregation = new AggregateResponse("nestedAggregation");
-        aggregation.addNestedAggregation(nestedAggregation);
+        AggregateResponse nestedAggregation =
+                new AggregateResponse("nestedAggregation", new AggregationResultsManager(),
+                        new LinkedHashSet(), new LinkedHashSet(), 5);
+        nestedAggregations.add(nestedAggregation);
 
         assertThat(aggregation.isPopulated(), is(true));
     }
 
     @Test
-    public void aggregationWithABucketAndNoResultAndNoNestingsReturnsTrueWhenQueriedIfItsPopulated()
+    public void aggregationWithABucketAndNoResultAndNoNestedResultsReturnsTrueWhenQueriedIfItsPopulated()
             throws Exception {
         AggregationBucket bucket = new AggregationBucket("value");
-        aggregation.addBucket(bucket);
+        this.buckets.add(bucket);
 
         assertThat(aggregation.isPopulated(), is(true));
     }
 
     @Test
-    public void aggregationSetDistinctValueCount(){
-        aggregation.setDistinctValuesCount(12);
-        assertThat(aggregation.getDistinctValuesCount(), is(12));
+    public void aggregationSetDistinctValueCount() {
+        assertThat(aggregation.getDistinctValuesCount(), is(DISTINCT_VALUES_COUNT));
     }
 }

--- a/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/solr/AggregateRequestToStringConverterTest.java
+++ b/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/solr/AggregateRequestToStringConverterTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.IsNot.not;
 import static uk.ac.ebi.quickgo.rest.search.query.AggregateRequest.DEFAULT_AGGREGATE_LIMIT;
+import static uk.ac.ebi.quickgo.rest.search.solr.AggregateToStringConverter.NUM_BUCKETS_TRUE;
 import static uk.ac.ebi.quickgo.rest.search.solr.AggregateToStringConverter.convertToSolrAggregation;
 import static uk.ac.ebi.quickgo.rest.search.solr.AggregateToStringConverter.createFacetField;
 import static uk.ac.ebi.quickgo.rest.search.solr.AggregateToStringConverter.createFacetType;
@@ -31,7 +32,6 @@ public class AggregateRequestToStringConverterTest {
     private static final String GP_ID_FIELD = "geneProductId";
     private static final String ANN_ID_FIELD = "annId";
     private static final String GO_ID_TYPE = "goId";
-    private static final String LIMIT = "limit";
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -171,6 +171,7 @@ public class AggregateRequestToStringConverterTest {
         assertThat(convertedAggregation, containsString(aggregatePrefixWithTypeTitle(GO_ID_TYPE)));
         assertThat(convertedAggregation, containsString(createFacetType(FACET_TYPE_TERM)));
         assertThat(convertedAggregation, containsString(createFacetField(GO_ID_TYPE)));
+        assertThat(convertedAggregation, containsString(NUM_BUCKETS_TRUE));
     }
 
     @Test
@@ -186,6 +187,7 @@ public class AggregateRequestToStringConverterTest {
         assertThat(convertedAggregation, containsString(createFacetType(FACET_TYPE_TERM)));
         assertThat(convertedAggregation, containsString(createFacetField(GO_ID_TYPE)));
         assertThat(convertedAggregation, containsString(createLimitField(limit)));
+        assertThat(convertedAggregation, containsString(NUM_BUCKETS_TRUE));
     }
 
     @Test
@@ -200,6 +202,7 @@ public class AggregateRequestToStringConverterTest {
         assertThat(convertedAggregation, containsString(createFacetType(FACET_TYPE_TERM)));
         assertThat(convertedAggregation, containsString(createFacetField(GO_ID_TYPE)));
         assertThat(convertedAggregation, containsString(createLimitField(DEFAULT_AGGREGATE_LIMIT)));
+        assertThat(convertedAggregation, containsString(NUM_BUCKETS_TRUE));
     }
 
     @Test
@@ -215,6 +218,7 @@ public class AggregateRequestToStringConverterTest {
         assertThat(convertedAggregation, containsString(createFacetType(FACET_TYPE_TERM)));
         assertThat(convertedAggregation, containsString(createFacetField(GO_ID_TYPE)));
         assertThat(convertedAggregation, containsString(createSolrCOUNTAggregation(GO_ID_TYPE, COUNT_FUNCTION)));
+        assertThat(convertedAggregation, containsString(NUM_BUCKETS_TRUE));
     }
 
     private String createSolrAggregation(String field, AggregateFunction function) {

--- a/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/solr/SolrAggregationHelperTest.java
+++ b/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/solr/SolrAggregationHelperTest.java
@@ -93,7 +93,7 @@ public class SolrAggregationHelperTest {
     }
 
     @Test
-    public void fieldWithCountPrefixReturnsAnCountPrefixWhenExtractingPrefix() throws Exception {
+    public void fieldWithCountPrefixReturnsCountPrefixWhenExtractingPrefix() throws Exception {
         String prefix = fieldPrefixExtractor(aggregateFieldTitle(COUNT_FUNCTION, GP_ID_FIELD));
 
         assertThat(prefix, is(COUNT_FUNCTION.getName()));
@@ -115,7 +115,7 @@ public class SolrAggregationHelperTest {
     }
 
     @Test
-    public void fieldWithCountPrefixReturnsAnTheFieldWhenExtractingField() throws Exception {
+    public void fieldWithCountPrefixReturnsFieldWhenExtractingField() throws Exception {
         String field = fieldNameExtractor(aggregateFieldTitle(COUNT_FUNCTION, GP_ID_FIELD));
 
         assertThat(field, is(GP_ID_FIELD));

--- a/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/solr/SolrAggregationHelperTest.java
+++ b/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/solr/SolrAggregationHelperTest.java
@@ -7,9 +7,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.Assert.*;
+import static uk.ac.ebi.quickgo.rest.search.solr.AggregateToStringConverter.NUM_BUCKETS;
 import static uk.ac.ebi.quickgo.rest.search.solr.SolrAggregationHelper.*;
 
 /**
@@ -78,7 +78,7 @@ public class SolrAggregationHelperTest {
     }
 
     @Test
-    public void nullPrefixedFieldThrowsExceptionWhenExtratingPrefix() throws Exception {
+    public void nullPrefixedFieldThrowsExceptionWhenExtractingPrefix() throws Exception {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Cannot extract prefix from null input");
 
@@ -86,21 +86,21 @@ public class SolrAggregationHelperTest {
     }
 
     @Test
-    public void fieldWithNoPrefixReturnsAnEmptyPrefixWhenExtratingPrefix() throws Exception {
+    public void fieldWithNoPrefixReturnsAnEmptyPrefixWhenExtractingPrefix() throws Exception {
         String prefix = fieldPrefixExtractor(GP_ID_FIELD);
 
         assertThat(prefix, isEmptyString());
     }
 
     @Test
-    public void fieldWithCountPrefixReturnsAnCountPrefixWhenExtratingPrefix() throws Exception {
+    public void fieldWithCountPrefixReturnsAnCountPrefixWhenExtractingPrefix() throws Exception {
         String prefix = fieldPrefixExtractor(aggregateFieldTitle(COUNT_FUNCTION, GP_ID_FIELD));
 
         assertThat(prefix, is(COUNT_FUNCTION.getName()));
     }
 
     @Test
-    public void nullPrefixedFieldThrowsExceptionWhenExtratingField() throws Exception {
+    public void nullPrefixedFieldThrowsExceptionWhenExtractingField() throws Exception {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Cannot extract field from null input");
 
@@ -108,17 +108,26 @@ public class SolrAggregationHelperTest {
     }
 
     @Test
-    public void emptyPrefixedFieldThrowsExceptionWhenExtratingField() throws Exception {
+    public void emptyPrefixedFieldThrowsExceptionWhenExtractingField() throws Exception {
         String fieldName = fieldNameExtractor("");
 
         assertThat(fieldName, isEmptyString());
     }
 
     @Test
-    public void fieldWithCountPrefixReturnsAnTheFieldWhenExtratingField() throws Exception {
+    public void fieldWithCountPrefixReturnsAnTheFieldWhenExtractingField() throws Exception {
         String field = fieldNameExtractor(aggregateFieldTitle(COUNT_FUNCTION, GP_ID_FIELD));
 
         assertThat(field, is(GP_ID_FIELD));
     }
 
+    @Test
+    public void testForNumBucketsReturnsTrue(){
+        assertThat(distinctValueCountTester(NUM_BUCKETS), is(true)) ;
+    }
+
+    @Test
+    public void testForNumBucketsReturnsFalse(){
+        assertThat(distinctValueCountTester("bucketHead"), is(false)) ;
+    }
 }

--- a/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/solr/SolrAggregationHelperTest.java
+++ b/rest-common/src/test/java/uk/ac/ebi/quickgo/rest/search/solr/SolrAggregationHelperTest.java
@@ -123,11 +123,11 @@ public class SolrAggregationHelperTest {
 
     @Test
     public void testForNumBucketsReturnsTrue(){
-        assertThat(distinctValueCountTester(NUM_BUCKETS), is(true)) ;
+        assertThat(isDistinctValueCount(NUM_BUCKETS), is(true));
     }
 
     @Test
     public void testForNumBucketsReturnsFalse(){
-        assertThat(distinctValueCountTester("bucketHead"), is(false)) ;
+        assertThat(isDistinctValueCount("bucketHead"), is(false));
     }
 }


### PR DESCRIPTION
Achieve this by adding numBuckets:true to get agg_facet request

Changes response from solr to 
   "unique_geneProductId": 41458221,
    "agg_evidenceCode": {
      "numBuckets": 35,
      "buckets": [
        {
          "val": "ECO:0000256",
          "count": 88001168,
          "unique_geneProductId": 38321802,
          "count_id": 88001168
        },
        {
          "val": "ECO:0000323",
          "count": 50206450,
          "unique_geneProductId": 25361638,
          "count_id": 50206450
        },
 ...

And the resulting json from the rest service
  "groupName": "annotation",
      "totalHits": 27,
      "types": [
        {
          "type": "reference",
          "distinctValueCount": 9,
          "values": [
            {
              "key": "PMID:25911094",
              "percentage": 0.4074074074074074,
              "hits": 11,
              "name": null
            },
            {
              "key": "GO_REF:0000037",
              "percentage": 0.14814814814814814,
              "hits": 4,
              "name": null
            },
            {
              "key": "GO_REF:0000107",
              "percentage": 0.14814814814814814,
              "hits": 4,
              "name": null
            },
            {
              "key": "GO_REF:0000039",
              "percentage": 0.1111111111111111,
              "hits": 3,
              "name": null
            },
            {
              "key": "PMID:14647039",
              "percentage": 0.037037037037037035,
              "hits": 1,
              "name": null
            },
            {
              "key": "PMID:16674676",
              "percentage": 0.037037037037037035,
              "hits": 1,
              "name": null
            },
            {
              "key": "Reactome:R-HSA-392499",
              "percentage": 0.037037037037037035,
              "hits": 1,
              "name": null
            },
            {
              "key": "Reactome:R-HSA-976734",
              "percentage": 0.037037037037037035,
              "hits": 1,
              "name": null
            },
            {
              "key": "Reactome:R-HSA-977136",
              "percentage": 0.037037037037037035,
              "hits": 1,
              "name": null
            }
          ]
   