### PR TITLE
Goa 3070 improve download file name

### DIFF
--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/download/http/MediaTypeFactory.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/download/http/MediaTypeFactory.java
@@ -1,8 +1,6 @@
 package uk.ac.ebi.quickgo.annotation.download.http;
 
 import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.Map;
 import org.springframework.http.MediaType;
 
 /**
@@ -13,35 +11,31 @@ import org.springframework.http.MediaType;
  * Created with IntelliJ IDEA.
  */
 public class MediaTypeFactory {
-    private static final String TEXT_TYPE = "text";
-    private static final String APPLICATION_TYPE = "application";
-    private static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
-
     public static final String TSV_SUB_TYPE = "tsv";
     public static final String GAF_SUB_TYPE = "gaf";
     public static final String GPAD_SUB_TYPE = "gpad";
-    private static final String EXCEL_SUB_TYPE = "vnd.ms-excel";
-    private static final String JSON_SUB_TYPE = "json";
-
+    private static final String TEXT_TYPE = "text";
     public static final String TSV_MEDIA_TYPE_STRING = TEXT_TYPE + "/" + TSV_SUB_TYPE;
     public static final String GAF_MEDIA_TYPE_STRING = TEXT_TYPE + "/" + GAF_SUB_TYPE;
     public static final String GPAD_MEDIA_TYPE_STRING = TEXT_TYPE + "/" + GPAD_SUB_TYPE;
-    public static final String EXCEL_MEDIA_TYPE_STRING = APPLICATION_TYPE + "/" + EXCEL_SUB_TYPE;
-    public static final String JSON_MEDIA_TYPE_STRING = APPLICATION_TYPE + "/" + JSON_SUB_TYPE;
-
+    private static final String APPLICATION_TYPE = "application";
+    private static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
     public static final MediaType TSV_MEDIA_TYPE = new MediaType(TEXT_TYPE, TSV_SUB_TYPE, DEFAULT_CHARSET);
     public static final MediaType GAF_MEDIA_TYPE = new MediaType(TEXT_TYPE, GAF_SUB_TYPE, DEFAULT_CHARSET);
     public static final MediaType GPAD_MEDIA_TYPE = new MediaType(TEXT_TYPE, GPAD_SUB_TYPE, DEFAULT_CHARSET);
-
+    private static final String EXCEL_SUB_TYPE = "vnd.ms-excel";
+    public static final String EXCEL_MEDIA_TYPE_STRING = APPLICATION_TYPE + "/" + EXCEL_SUB_TYPE;
     public static final MediaType EXCEL_MEDIA_TYPE = new MediaType(APPLICATION_TYPE, EXCEL_SUB_TYPE);
+    private static final String JSON_SUB_TYPE = "json";
+    public static final String JSON_MEDIA_TYPE_STRING = APPLICATION_TYPE + "/" + JSON_SUB_TYPE;
     public static final MediaType JSON_MEDIA_TYPE = new MediaType(APPLICATION_TYPE, JSON_SUB_TYPE);
     private static final String EXCEL_FILE_TYPE = "xls";
 
-    public static String fileExtension(MediaType mediaType){
-       if( EXCEL_MEDIA_TYPE.equals(mediaType)){
-           return EXCEL_FILE_TYPE;
-       }
-       return mediaType.getSubtype();
+    public static String fileExtension(MediaType mediaType) {
+        if (EXCEL_MEDIA_TYPE.equals(mediaType)) {
+            return EXCEL_FILE_TYPE;
+        }
+        return mediaType.getSubtype();
     }
 
 }

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/download/http/MediaTypeFactory.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/download/http/MediaTypeFactory.java
@@ -20,8 +20,8 @@ public class MediaTypeFactory {
     public static final String TSV_SUB_TYPE = "tsv";
     public static final String GAF_SUB_TYPE = "gaf";
     public static final String GPAD_SUB_TYPE = "gpad";
-    public static final String EXCEL_SUB_TYPE = "vnd.ms-excel";
-    public static final String JSON_SUB_TYPE = "json";
+    private static final String EXCEL_SUB_TYPE = "vnd.ms-excel";
+    private static final String JSON_SUB_TYPE = "json";
 
     public static final String TSV_MEDIA_TYPE_STRING = TEXT_TYPE + "/" + TSV_SUB_TYPE;
     public static final String GAF_MEDIA_TYPE_STRING = TEXT_TYPE + "/" + GAF_SUB_TYPE;
@@ -35,19 +35,13 @@ public class MediaTypeFactory {
 
     public static final MediaType EXCEL_MEDIA_TYPE = new MediaType(APPLICATION_TYPE, EXCEL_SUB_TYPE);
     public static final MediaType JSON_MEDIA_TYPE = new MediaType(APPLICATION_TYPE, JSON_SUB_TYPE);
-
-    private static Map<MediaType, String> MEDIA_TYPE_TO_FILE_EXTENSIONS = new HashMap<>();
-
-    static {
-        MEDIA_TYPE_TO_FILE_EXTENSIONS.put(TSV_MEDIA_TYPE, TSV_SUB_TYPE);
-        MEDIA_TYPE_TO_FILE_EXTENSIONS.put(GAF_MEDIA_TYPE, GAF_SUB_TYPE);
-        MEDIA_TYPE_TO_FILE_EXTENSIONS.put(GPAD_MEDIA_TYPE, GPAD_SUB_TYPE);
-        MEDIA_TYPE_TO_FILE_EXTENSIONS.put(EXCEL_MEDIA_TYPE, "xls");
-        MEDIA_TYPE_TO_FILE_EXTENSIONS.put(JSON_MEDIA_TYPE, JSON_SUB_TYPE);
-    }
+    private static final String EXCEL_FILE_TYPE = "xls";
 
     public static String fileExtension(MediaType mediaType){
-        return MEDIA_TYPE_TO_FILE_EXTENSIONS.get(mediaType);
+       if( EXCEL_MEDIA_TYPE.equals(mediaType)){
+           return EXCEL_FILE_TYPE;
+       }
+       return mediaType.getSubtype();
     }
 
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/download/http/MediaTypeFactoryTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/download/http/MediaTypeFactoryTest.java
@@ -1,0 +1,37 @@
+package uk.ac.ebi.quickgo.annotation.download.http;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.ac.ebi.quickgo.annotation.download.http.MediaTypeFactory.EXCEL_MEDIA_TYPE;
+
+/**
+ * Test the functionality in MediaTypeFactory
+ *
+ * @author Tony Wardell
+ * Date: 20/11/2017
+ * Time: 16:34
+ * Created with IntelliJ IDEA.
+ */
+public class MediaTypeFactoryTest {
+
+    @Test
+    public void requestedMediaTypeWithoutCharacterSet(){
+        assertThat(MediaTypeFactory.fileExtension(new MediaType("text","tsv")), is("tsv"));
+    }
+
+    @Test
+    public void requestedMediaTypeWithUTF8(){
+        assertThat(MediaTypeFactory.fileExtension(new MediaType("text","tsv", StandardCharsets.UTF_8)),
+                is("tsv"));
+    }
+
+    @Test
+    public void requestedMediaTypeIsExcel(){
+        assertThat(MediaTypeFactory.fileExtension(EXCEL_MEDIA_TYPE), is("xls"));
+    }
+
+}

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/download/http/MediaTypeFactoryTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/download/http/MediaTypeFactoryTest.java
@@ -19,19 +19,18 @@ import static uk.ac.ebi.quickgo.annotation.download.http.MediaTypeFactory.EXCEL_
 public class MediaTypeFactoryTest {
 
     @Test
-    public void requestedMediaTypeWithoutCharacterSet(){
-        assertThat(MediaTypeFactory.fileExtension(new MediaType("text","tsv")), is("tsv"));
+    public void requestedMediaTypeWithoutCharacterSet() {
+        assertThat(MediaTypeFactory.fileExtension(new MediaType("text", "tsv")), is("tsv"));
     }
 
     @Test
-    public void requestedMediaTypeWithUTF8(){
-        assertThat(MediaTypeFactory.fileExtension(new MediaType("text","tsv", StandardCharsets.UTF_8)),
+    public void requestedMediaTypeWithUTF8() {
+        assertThat(MediaTypeFactory.fileExtension(new MediaType("text", "tsv", StandardCharsets.UTF_8)),
                 is("tsv"));
     }
 
     @Test
-    public void requestedMediaTypeIsExcel(){
+    public void requestedMediaTypeIsExcel() {
         assertThat(MediaTypeFactory.fileExtension(EXCEL_MEDIA_TYPE), is("xls"));
     }
-
 }


### PR DESCRIPTION
When a download file is requested from the QuickGO backend, if the character set is not defined as part of the accept header, then the media type definition created does not match what is expected - the result is the file type i.e what should be .tsv or .gaf etc appears as null.
We can make the test of media type to be more simple and flexible to avoid these nulls.