### PR TITLE
allow filtering of slimmed from terms for ontology slimming service

### DIFF
--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/converter/SlimmingFilterConverter.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/converter/SlimmingFilterConverter.java
@@ -29,14 +29,14 @@ public class SlimmingFilterConverter extends AbstractOntologyFilterConverter {
     }
 
     @Override protected boolean validResult(OntologyRelatives.Result result) {
-        return nonNull(result.getSlimsTo());
+        return nonNull(result.getSlimsToIds());
     }
 
     @Override protected void processResult(OntologyRelatives.Result result, Set<QuickGOQuery> queries) {
-        queries.add(createQueryForOntologyId(result.getId()));
-        result.getSlimsTo().stream()
+        queries.add(createQueryForOntologyId(result.getSlimsFromId()));
+        result.getSlimsToIds().stream()
                 .filter(slim -> !Strings.isNullOrEmpty(slim))
-                .forEach(slimId -> conversionInfo.addOriginal2SlimmedGOIdMapping(result.getId(), slimId)
+                .forEach(slimId -> conversionInfo.addOriginal2SlimmedGOIdMapping(result.getSlimsFromId(), slimId)
                 );
     }
 

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/model/OntologyRelatives.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/model/OntologyRelatives.java
@@ -13,7 +13,7 @@ import java.util.List;
  * </ul>
  *
  * Currently, this model captures the parts reached by the JSON path expressions, "$.results.descendants" or
- * "$.results.slimsTo".
+ * "$.results.slimsToIds".
  *
  * Created 09/08/16
  * @author Edd
@@ -41,15 +41,24 @@ public class OntologyRelatives implements ResponseType {
         public Result() {}
 
         private String id;
-        private List<String> slimsTo;
+        private String slimsFromId;
+        private List<String> slimsToIds;
         private List<String> descendants;
 
-        public List<String> getSlimsTo() {
-            return slimsTo;
+        public String getSlimsFromId() {
+            return slimsFromId;
         }
 
-        public void setSlimsTo(List<String> slimsTo) {
-            this.slimsTo = slimsTo;
+        public void setSlimsFromId(String slimsFromId) {
+            this.slimsFromId = slimsFromId;
+        }
+
+        public List<String> getSlimsToIds() {
+            return slimsToIds;
+        }
+
+        public void setSlimsToIds(List<String> slimsToIds) {
+            this.slimsToIds = slimsToIds;
         }
 
         public List<String> getDescendants() {
@@ -71,7 +80,8 @@ public class OntologyRelatives implements ResponseType {
         @Override public String toString() {
             return "Result{" +
                     "id='" + id + '\'' +
-                    ", slimsTo=" + slimsTo +
+                    ", slimsFromId='" + slimsFromId + '\'' +
+                    ", slimsToIds=" + slimsToIds +
                     ", descendants=" + descendants +
                     '}';
         }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AbstractFilterAnnotationByOntologyRESTIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AbstractFilterAnnotationByOntologyRESTIT.java
@@ -459,8 +459,9 @@ public abstract class AbstractFilterAnnotationByOntologyRESTIT {
                 .andRespond(response);
     }
 
-    String constructResponseObject(List<String> termIds, List<List<String>> values,
-            BiConsumer<OntologyRelatives.Result, List<String>> resultValueUpdater) {
+    String constructResponseObject(
+            List<String> termIds, BiConsumer<OntologyRelatives.Result, String> resultSourceUpdater,
+            List<List<String>> values, BiConsumer<OntologyRelatives.Result, List<String>> resultValueUpdater) {
         checkArgument(termIds != null, "termIds cannot be null");
         checkArgument(values != null, "values cannot be null");
         checkArgument(termIds.size() == values.size(), "Term ID list and the (list of lists) of their " +
@@ -473,7 +474,8 @@ public abstract class AbstractFilterAnnotationByOntologyRESTIT {
         Iterator<List<String>> valuesListsIterator = values.iterator();
         termIds.forEach(t -> {
             OntologyRelatives.Result result = new OntologyRelatives.Result();
-            result.setId(t);
+            //            result.setId(t);
+            resultSourceUpdater.accept(result, t);
             resultValueUpdater.accept(result, valuesListsIterator.next());
             results.add(result);
         });
@@ -511,6 +513,8 @@ public abstract class AbstractFilterAnnotationByOntologyRESTIT {
                         resourceFormat,
                         termIdsCSV,
                         relationsCSV),
-                constructResponseObject(termIds, descendants, OntologyRelatives.Result::setDescendants));
+                constructResponseObject(
+                        termIds, OntologyRelatives.Result::setId,
+                        descendants, OntologyRelatives.Result::setDescendants));
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/FilterAnnotationByGORESTIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/FilterAnnotationByGORESTIT.java
@@ -32,7 +32,7 @@ import static uk.ac.ebi.quickgo.annotation.controller.ResponseVerifier.*;
  */
 public class FilterAnnotationByGORESTIT extends AbstractFilterAnnotationByOntologyRESTIT {
     private static final String GO_DESCENDANTS_RESOURCE_FORMAT = "/ontology/go/terms/%s/descendants?relations=%s";
-    private static final String GO_SLIM_RESOURCE_FORMAT = "/ontology/go/slim?ids=%s&relations=%s";
+    private static final String GO_SLIM_RESOURCE_FORMAT = "/ontology/go/slim?slimsToIds=%s&relations=%s";
 
     public FilterAnnotationByGORESTIT() {
         resourceFormat = GO_DESCENDANTS_RESOURCE_FORMAT;

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/FilterAnnotationByGORESTIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/FilterAnnotationByGORESTIT.java
@@ -265,12 +265,6 @@ public class FilterAnnotationByGORESTIT extends AbstractFilterAnnotationByOntolo
             List<String> usageRelations,
             List<List<String>> slims) {
 
-//        expectRestCallHasValues(
-//                GO_SLIM_RESOURCE_FORMAT,
-//                termIds,
-//                usageRelations,
-//                slims,
-//                OntologyRelatives.Result::setSlimsTo);
         String slimTermsCSV = slims.stream()
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
@@ -285,6 +279,7 @@ public class FilterAnnotationByGORESTIT extends AbstractFilterAnnotationByOntolo
                         GO_SLIM_RESOURCE_FORMAT,
                         slimTermsCSV,
                         relationsCSV),
-                constructResponseObject(termIds, slims, OntologyRelatives.Result::setSlimsTo));
+                constructResponseObject(termIds, OntologyRelatives.Result::setSlimsFromId,
+                        slims, OntologyRelatives.Result::setSlimsToIds));
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/descendants/SlimmingFilterConverterTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/descendants/SlimmingFilterConverterTest.java
@@ -140,17 +140,17 @@ public class SlimmingFilterConverterTest {
 
     private void addResponseSlimsTo(String termId, String slimId) {
         for (OntologyRelatives.Result result : response.getResults()) {
-            if (result.getId().equals(termId)) {
-                result.getSlimsTo().add(slimId);
+            if (result.getSlimsFromId().equals(termId)) {
+                result.getSlimsToIds().add(slimId);
                 return;
             }
         }
 
         OntologyRelatives.Result newResult = new OntologyRelatives.Result();
-        newResult.setId(termId);
+        newResult.setSlimsFromId(termId);
         List<String> slimList = new ArrayList<>();
         slimList.add(slimId);
-        newResult.setSlimsTo(slimList);
+        newResult.setSlimsToIds(slimList);
         response.getResults().add(newResult);
     }
 }

--- a/annotation-rest/src/test/resources/application.yml
+++ b/annotation-rest/src/test/resources/application.yml
@@ -41,7 +41,7 @@ search:
         execution: REST_COMM
         properties: {
           ip: "https://localhost",
-          resourceFormat: "/ontology/go/slim?ids={goId}&relations={goUsageRelationships}",
+          resourceFormat: "/ontology/go/slim?slimsToIds={goId}&relations={goUsageRelationships}",
           responseClass: "uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.OntologyRelatives",
           responseConverter: "uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.converter.SlimmingFilterConverter"
         }

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/SlimTerm.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/SlimTerm.java
@@ -11,11 +11,11 @@ import java.util.List;
  * @author Edd
  */
 public class SlimTerm {
-    public SlimTerm(String id, List<String> slimmedTerms) {
-        this.id = id;
-        this.slimsTo = Collections.unmodifiableList(slimmedTerms);
+    public SlimTerm(String slimsFromId, List<String> slimmedTerms) {
+        this.slimsFromId = slimsFromId;
+        this.slimsToIds = Collections.unmodifiableList(slimmedTerms);
     }
 
-    public final String id;
-    public final List<String> slimsTo;
+    public final String slimsFromId;
+    public final List<String> slimsToIds;
 }

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/OntologyService.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/OntologyService.java
@@ -130,11 +130,13 @@ public interface OntologyService<T extends OBOTerm> {
      * Maps ids to their equivalent, slimmed ids. The results are presented as a list of {@link SlimTerm} instances,
      * each of which contains a term id, and which shows the ids to which this term slims to.
      *
-     * @param slimTerms the terms to which we want to find term ids that map "up" to.
+     * @param slimsFromTerms the terms from which we want slimming information. If omitted, defaults to all terms.
+     * @param slimsToTerms the terms that {@code slimsFromTerms} map "up" to, i.e., the "slim-set".
      * @param relationTypes the relationships over which the slimming calculation will traverse
      * @return a list of {@link SlimTerm} objects that provide the slimming information
      */
-    List<SlimTerm> findSlimmedInfoForSlimmedTerms(List<String> slimTerms, OntologyRelationType... relationTypes);
+    List<SlimTerm> findSlimmedInfoForSlimmedTerms(Set<String> slimsFromTerms, List<String> slimsToTerms,
+            OntologyRelationType... relationTypes);
 
     /**
      * Find the set of ancestor vertices reachable from a list of ids, {@code ids}, navigable via a specified

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/OntologyServiceImpl.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/OntologyServiceImpl.java
@@ -153,8 +153,8 @@ public class OntologyServiceImpl<T extends OBOTerm> implements OntologyService<T
         return slimmer.getSlimmedTermsMap().entrySet().stream()
                 .filter(this::doesNotSlimToOnlyItself)
                 .map(Map.Entry::getKey)
-                .filter(term -> isRequestedSlimFromTerm(term, slimsFromTerms))
-                .map(id -> new SlimTerm(id, slimmer.findSlims(id)))
+                .filter(term -> slimsFromTerms.isEmpty() || slimsFromTerms.contains(term))
+                .map(id -> new SlimTerm(id, slimmer.findSlimmedToTerms(id)))
                 .collect(Collectors.toList());
     }
 
@@ -246,10 +246,6 @@ public class OntologyServiceImpl<T extends OBOTerm> implements OntologyService<T
     private T insertDescendants(T term, OntologyRelationType... relations) {
         term.descendants = getRelatives(descendantFetcher, term, relations);
         return term;
-    }
-
-    private boolean isRequestedSlimFromTerm(String term, Set<String> slimFromTerms) {
-        return slimFromTerms.isEmpty() || slimFromTerms.contains(term);
     }
 
     /**

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/traversal/TermSlimmer.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/traversal/TermSlimmer.java
@@ -100,7 +100,7 @@ public class TermSlimmer {
      * @param id the identifier of the term to map
      * @return a list of terms within the original slim-set to which this term slims up to.
      */
-    public List<String> findSlims(String id) {
+    public List<String> findSlimmedToTerms(String id) {
         return slimTranslate.getOrDefault(id, emptyList());
     }
 

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
@@ -126,7 +126,7 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.id", contains(GO_SLIM_CHILD1)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD1)));
     }
 
     @Test
@@ -138,7 +138,7 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.id", contains(GO_SLIM_CHILD1)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD1)));
     }
 
     @Test
@@ -150,7 +150,7 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.id", contains(GO_SLIM_CHILD2)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD2)));
 
         mockMvc.perform(get(getSlimURL())
                 .param(SLIM_TO_IDS_PARAM, GO_SLIM3));
@@ -159,7 +159,7 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.id", contains(GO_SLIM_CHILD2)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD2)));
     }
 
     @Test
@@ -171,7 +171,7 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(2))
-                .andExpect(jsonPath("$.results.*.id", containsInAnyOrder(GO_SLIM_CHILD3, GO_SLIM_CHILD4)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD3, GO_SLIM_CHILD4)));
     }
 
     @Test
@@ -183,7 +183,7 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(2))
-                .andExpect(jsonPath("$.results.*.id", containsInAnyOrder(GO_SLIM_CHILD5, GO_SLIM_CHILD6)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD5, GO_SLIM_CHILD6)));
     }
 
     @Test
@@ -196,7 +196,7 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.id", containsInAnyOrder(GO_SLIM_CHILD5)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD5)));
     }
 
     @Test

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
@@ -6,8 +6,6 @@ import uk.ac.ebi.quickgo.ontology.model.OntologyRelationType;
 import uk.ac.ebi.quickgo.ontology.model.OntologyRelationship;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -16,6 +14,8 @@ import org.junit.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
@@ -78,7 +78,7 @@ public class GOControllerIT extends OBOControllerIT {
         ResultActions response = mockMvc.perform(get(
                 buildTermsURLWithSubResource(toCSV(GO_0000001, GO_0000002), CONSTRAINTS_SUB_RESOURCE)));
 
-        expectBasicFieldsInResults(response, Arrays.asList(GO_0000001, GO_0000002))
+        expectBasicFieldsInResults(response, asList(GO_0000001, GO_0000002))
                 .andExpect(jsonPath("$.results.*.blacklist", hasSize(2)))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
@@ -88,7 +88,7 @@ public class GOControllerIT extends OBOControllerIT {
     public void canRetrieveGoDiscussions() throws Exception {
         ResultActions response = mockMvc.perform(get(buildTermsURLWithSubResource(GO_0000001, COMPLETE_SUB_RESOURCE)));
 
-        expectBasicFieldsInResults(response, Collections.singletonList(GO_0000001))
+        expectBasicFieldsInResults(response, singletonList(GO_0000001))
                 .andExpect(jsonPath("$.results.*.goDiscussions", hasSize(1)))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
@@ -98,7 +98,7 @@ public class GOControllerIT extends OBOControllerIT {
     public void canRetrieveProteinComplexes() throws Exception {
         ResultActions response = mockMvc.perform(get(buildTermsURLWithSubResource(GO_0000001, COMPLETE_SUB_RESOURCE)));
 
-        expectBasicFieldsInResults(response, Collections.singletonList(GO_0000001))
+        expectBasicFieldsInResults(response, singletonList(GO_0000001))
                 .andExpect(jsonPath("$.results.*.proteinComplexes", hasSize(1)))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
@@ -126,19 +126,21 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD1)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD1)))
+                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM1)));
     }
 
     @Test
-    public void oneIdAndOneInvalidIdHasOneSlim() throws Exception {
+    public void oneIdAndOneNonExistingIdHasOneSlim() throws Exception {
         ResultActions response = mockMvc.perform(get(getSlimURL())
-                .param(SLIM_TO_IDS_PARAM, toCSV(GO_SLIM1, "GO:0000000")));
+                .param(SLIM_TO_IDS_PARAM, toCSV(GO_SLIM1, NON_EXISTENT_TERM)));
 
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD1)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD1)))
+                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM1)));
     }
 
     @Test
@@ -150,7 +152,8 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD2)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD2)))
+                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM2)));
 
         mockMvc.perform(get(getSlimURL())
                 .param(SLIM_TO_IDS_PARAM, GO_SLIM3));
@@ -159,7 +162,8 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD2)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD2)))
+                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM2)));
     }
 
     @Test
@@ -171,7 +175,8 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(2))
-                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD3, GO_SLIM_CHILD4)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD3, GO_SLIM_CHILD4)))
+                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM4, GO_SLIM4)));
     }
 
     @Test
@@ -183,7 +188,8 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(2))
-                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD5, GO_SLIM_CHILD6)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD5, GO_SLIM_CHILD6)))
+                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM5, GO_SLIM6, GO_SLIM5, GO_SLIM6)));
     }
 
     @Test
@@ -196,11 +202,12 @@ public class GOControllerIT extends OBOControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD5)));
+                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD5)))
+                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM5, GO_SLIM6)));
     }
 
     @Test
-    public void twoIdsHave2SlimsButOnlyNoneAreRequested() throws Exception {
+    public void twoIdsHave2SlimsButNoneAreRequested() throws Exception {
         ResultActions response = mockMvc.perform(get(getSlimURL())
                 .param(SLIM_TO_IDS_PARAM, toCSV(GO_SLIM5, GO_SLIM6))
                 .param(SLIM_FROM_IDS_PARAM, NON_EXISTENT_TERM));
@@ -223,10 +230,46 @@ public class GOControllerIT extends OBOControllerIT {
     @Test
     public void slimmingWithNoValidIDsCausesCauses400() throws Exception {
         ResultActions response = mockMvc.perform(get(getSlimURL())
-                .param(SLIM_TO_IDS_PARAM, "GO:0000000"));
+                .param(SLIM_TO_IDS_PARAM, NON_EXISTENT_TERM));
 
         expectResponseCreationError(response, NO_VALID_SLIM_TERMS_ERROR_MESSAGE)
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void slimmingWithInvalidFromIdButValidToIdProduces400() throws Exception {
+        ResultActions response = mockMvc.perform(get(getSlimURL())
+                .param(SLIM_FROM_IDS_PARAM, invalidId())
+                .param(SLIM_TO_IDS_PARAM, GO_SLIM1));
+
+        expectInvalidIdError(response, invalidId());
+    }
+
+    @Test
+    public void slimmingWithFromIdButNoToIdsProduces400() throws Exception {
+        ResultActions response = mockMvc.perform(get(getSlimURL())
+                .param(SLIM_FROM_IDS_PARAM, GO_SLIM_CHILD1));
+
+        expectResponseCreationError(response, MISSING_SLIM_SET_ERROR_MESSAGE)
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void slimmingWithFromIdButToIdIsInvalidProduces400() throws Exception {
+        ResultActions response = mockMvc.perform(get(getSlimURL())
+                .param(SLIM_FROM_IDS_PARAM, invalidId())
+                .param(SLIM_TO_IDS_PARAM, GO_SLIM1));
+
+        expectInvalidIdError(response, invalidId());
+    }
+
+    @Test
+    public void slimmingWithInvalidFromAndInvalidToIdProduces400() throws Exception {
+        ResultActions response = mockMvc.perform(get(getSlimURL())
+                .param(SLIM_FROM_IDS_PARAM, invalidId())
+                .param(SLIM_TO_IDS_PARAM, invalidId() + "XXX"));
+
+        expectInvalidIdError(response, invalidId());
     }
 
     @Test
@@ -237,7 +280,7 @@ public class GOControllerIT extends OBOControllerIT {
                 .param(SLIM_RELATIONS_PARAM, invalidRelation));
 
         expectInvalidRelationError(response, invalidRelation)
-            .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -266,13 +309,13 @@ public class GOControllerIT extends OBOControllerIT {
         return "part_of";
     }
 
-    @Override protected String getInvalidRelations(){
+    @Override protected String getInvalidRelations() {
         return "used_in";
     }
 
     @Override
     protected List<OntologyDocument> createBasicDocs() {
-        return Arrays.asList(
+        return asList(
                 OntologyDocMocker.createGODoc(GO_0000001, "doc name 1"),
                 OntologyDocMocker.createGODoc(GO_0000002, "doc name 2"),
                 OntologyDocMocker.createGODoc(GO_0000003, "doc name 3"),

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
@@ -257,8 +257,8 @@ public class GOControllerIT extends OBOControllerIT {
     @Test
     public void slimmingWithFromIdButToIdIsInvalidProduces400() throws Exception {
         ResultActions response = mockMvc.perform(get(getSlimURL())
-                .param(SLIM_FROM_IDS_PARAM, invalidId())
-                .param(SLIM_TO_IDS_PARAM, GO_SLIM1));
+                .param(SLIM_FROM_IDS_PARAM, GO_SLIM_CHILD1)
+                .param(SLIM_TO_IDS_PARAM, invalidId()));
 
         expectInvalidIdError(response, invalidId());
     }

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/traversal/TermSlimmerTest.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/traversal/TermSlimmerTest.java
@@ -1,24 +1,29 @@
 package uk.ac.ebi.quickgo.ontology.traversal;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import uk.ac.ebi.quickgo.ontology.common.OntologyType;
 import uk.ac.ebi.quickgo.ontology.model.OntologyRelationType;
 import uk.ac.ebi.quickgo.ontology.model.OntologyRelationship;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static uk.ac.ebi.quickgo.ontology.common.OntologyType.ECO;
-import static uk.ac.ebi.quickgo.ontology.model.OntologyRelationType.*;
+import static uk.ac.ebi.quickgo.ontology.model.OntologyRelationType.CAPABLE_OF_PART_OF;
+import static uk.ac.ebi.quickgo.ontology.model.OntologyRelationType.HAS_PART;
+import static uk.ac.ebi.quickgo.ontology.model.OntologyRelationType.IS_A;
+import static uk.ac.ebi.quickgo.ontology.model.OntologyRelationType.PART_OF;
 import static uk.ac.ebi.quickgo.ontology.traversal.TermSlimmer.DEFAULT_RELATION_TYPES;
 
 /**
@@ -103,11 +108,11 @@ public class TermSlimmerTest {
         List<String> slimSetVertices = singletonList(MEMBRANE);
         TermSlimmer termSlimmer = TermSlimmer.createSlims(OntologyType.GO, ontology, slimSetVertices);
         assertThat(termSlimmer.getSlimmedTermsMap().size(), is(5));
-        assertThat(termSlimmer.findSlims(MEMBRANE), contains(MEMBRANE));
-        assertThat(termSlimmer.findSlims(MEMBRANE_PART), contains(MEMBRANE));
-        assertThat(termSlimmer.findSlims(PLASMA_MEMBRANE), contains(MEMBRANE));
-        assertThat(termSlimmer.findSlims(PLASMA_MEMBRANE_PART), contains(MEMBRANE));
-        assertThat(termSlimmer.findSlims(LATERAL_PLASMA_MEMBRANE), contains(MEMBRANE));
+        assertThat(termSlimmer.findSlimmedToTerms(MEMBRANE), contains(MEMBRANE));
+        assertThat(termSlimmer.findSlimmedToTerms(MEMBRANE_PART), contains(MEMBRANE));
+        assertThat(termSlimmer.findSlimmedToTerms(PLASMA_MEMBRANE), contains(MEMBRANE));
+        assertThat(termSlimmer.findSlimmedToTerms(PLASMA_MEMBRANE_PART), contains(MEMBRANE));
+        assertThat(termSlimmer.findSlimmedToTerms(LATERAL_PLASMA_MEMBRANE), contains(MEMBRANE));
     }
 
     @Test
@@ -115,12 +120,12 @@ public class TermSlimmerTest {
         List<String> slimSetVertices = asList(CELL_PART, MEMBRANE_PART);
         TermSlimmer termSlimmer = TermSlimmer.createSlims(OntologyType.GO, ontology, slimSetVertices);
         assertThat(termSlimmer.getSlimmedTermsMap().size(), is(6));
-        assertThat(termSlimmer.findSlims(CELL_PART), contains(CELL_PART));
-        assertThat(termSlimmer.findSlims(MEMBRANE_PART), contains(MEMBRANE_PART));
-        assertThat(termSlimmer.findSlims(CELL_PERIPHERY), contains(CELL_PART));
-        assertThat(termSlimmer.findSlims(PLASMA_MEMBRANE), contains(CELL_PART));
-        assertThat(termSlimmer.findSlims(PLASMA_MEMBRANE_PART), contains(CELL_PART, MEMBRANE_PART));
-        assertThat(termSlimmer.findSlims(LATERAL_PLASMA_MEMBRANE), contains(CELL_PART, MEMBRANE_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(CELL_PART), contains(CELL_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(MEMBRANE_PART), contains(MEMBRANE_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(CELL_PERIPHERY), contains(CELL_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(PLASMA_MEMBRANE), contains(CELL_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(PLASMA_MEMBRANE_PART), contains(CELL_PART, MEMBRANE_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(LATERAL_PLASMA_MEMBRANE), contains(CELL_PART, MEMBRANE_PART));
     }
 
     @Test
@@ -128,24 +133,24 @@ public class TermSlimmerTest {
         List<String> slimSetVertices = asList(CELL_PART, MEMBRANE_PART, PLASMA_MEMBRANE_PART);
         TermSlimmer termSlimmer = TermSlimmer.createSlims(OntologyType.GO, ontology, slimSetVertices);
         assertThat(termSlimmer.getSlimmedTermsMap().size(), is(6));
-        assertThat(termSlimmer.findSlims(CELL_PART), contains(CELL_PART));
-        assertThat(termSlimmer.findSlims(MEMBRANE_PART), contains(MEMBRANE_PART));
-        assertThat(termSlimmer.findSlims(CELL_PERIPHERY), contains(CELL_PART));
-        assertThat(termSlimmer.findSlims(PLASMA_MEMBRANE), contains(CELL_PART));
-        assertThat(termSlimmer.findSlims(PLASMA_MEMBRANE_PART), contains(PLASMA_MEMBRANE_PART));
-        assertThat(termSlimmer.findSlims(LATERAL_PLASMA_MEMBRANE), contains(PLASMA_MEMBRANE_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(CELL_PART), contains(CELL_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(MEMBRANE_PART), contains(MEMBRANE_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(CELL_PERIPHERY), contains(CELL_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(PLASMA_MEMBRANE), contains(CELL_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(PLASMA_MEMBRANE_PART), contains(PLASMA_MEMBRANE_PART));
+        assertThat(termSlimmer.findSlimmedToTerms(LATERAL_PLASMA_MEMBRANE), contains(PLASMA_MEMBRANE_PART));
     }
 
     @Test
     public void termInOntologySlimsToNothing() {
         TermSlimmer termSlimmer = TermSlimmer.createSlims(OntologyType.GO, ontology, singletonList(CELL));
-        assertThat(termSlimmer.findSlims(CELLULAR_COMPONENT), is(empty()));
+        assertThat(termSlimmer.findSlimmedToTerms(CELLULAR_COMPONENT), is(empty()));
     }
 
     @Test
     public void termNotInOntologySlimsToNothing() {
         TermSlimmer termSlimmer = TermSlimmer.createSlims(OntologyType.GO, ontology, singletonList(CELLULAR_COMPONENT));
-        assertThat(termSlimmer.findSlims("XXXXXX"), is(empty()));
+        assertThat(termSlimmer.findSlimmedToTerms("XXXXXX"), is(empty()));
     }
 
     /**


### PR DESCRIPTION
Previously, the ontology slimming service showed a map of <termId, slimmedToTermIdList>, where the keys of this map is the entire ontology. A new use case has come in where it is wanted that the keys of this map to be filtered to only those they specify. Therefore, a new request parameter `slimsFromIds` has been introduced to filter the keys to only those that are desired.