### PR TITLE
Goa 3078 add term and taxon names to statistics endpoint

### DIFF
--- a/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocMocker.java
+++ b/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocMocker.java
@@ -22,26 +22,12 @@ import static java.util.Arrays.asList;
  * @author Edd
  */
 public class AnnotationDocMocker {
-
+    public static AtomicLong rowNumberGenerator = new AtomicLong();
     public static final String GO_ID = "GO:0003824";
     public static final String ECO_ID = "ECO:0000256";
-    private static final String QUALIFIER = "enables";
-    private static final String GO_EVIDENCE = "IEA";
     public static final String REFERENCE = "GO_REF:0000002";
-    private static final List<String> WITH_FROM = asList("InterPro:IPR015421", "InterPro:IPR015422");
-    private static final int INTERACTING_TAXON_ID = 35758;
-    private static final String ASSIGNED_BY = "InterPro";
-    private static final String SYMBOL = "moeA5";
-    private static final String OBJECT_TYPE = "protein";
     public static final int TAXON_ID = 12345;
-    private static final List<Integer> TAXON_ANCESTORS = asList(12345, 1234, 123, 12, 1);
-
-    private static final List<String> TARGET_SET = asList("KRUK", "BHF-UCL", "Exosome");
-    private static final String GP_SUBSET = "TrEMBL";
     public static final String GO_ASPECT = "cellular_component";
-    private static final Date DATE = Date.from(
-            LocalDate.of(1869, 10, 2).atStartOfDay(ZoneId.systemDefault()).toInstant());
-
     public static final String EXTENSION_DB1 = "NCBI_gi";
     public static final String EXTENSION_DB2 = "Cl";
     public static final String EXTENSION_DB3 = "UBERON-AG";
@@ -54,7 +40,6 @@ public class AnnotationDocMocker {
     private static final String EXTENSION_RELATIONSHIP2 = "acts_on_population_of";
     private static final String EXTENSION_RELATIONSHIP3 = "indicative_of";
     private static final String EXTENSION_RELATIONSHIP4 = "happy_about";
-
     public static final String EXTENSION_1 = asExtension(EXTENSION_RELATIONSHIP1, EXTENSION_DB1, EXTENSION_ID1);
     public static final String EXTENSION_2 = asExtension(EXTENSION_RELATIONSHIP2, EXTENSION_DB2, EXTENSION_ID2);
     public static final String EXTENSION_3 = asExtension(EXTENSION_RELATIONSHIP3, EXTENSION_DB3, EXTENSION_ID3);
@@ -62,7 +47,18 @@ public class AnnotationDocMocker {
     public static final List<String> EXTENSIONS = asList(String.format("%s,%s", EXTENSION_1, EXTENSION_2), String
             .format("%s,%s",EXTENSION_3, EXTENSION_4));
 
-    public static AtomicLong rowNumberGenerator = new AtomicLong();
+    private static final Date DATE = Date.from(
+            LocalDate.of(1869, 10, 2).atStartOfDay(ZoneId.systemDefault()).toInstant());
+    private static final String OBJECT_TYPE = "protein";
+    private static final List<Integer> TAXON_ANCESTORS = asList(12345, 1234, 123, 12, 1);
+    private static final String QUALIFIER = "enables";
+    private static final String GO_EVIDENCE = "IEA";
+    private static final List<String> TARGET_SET = asList("KRUK", "BHF-UCL", "Exosome");
+    private static final String GP_SUBSET = "TrEMBL";
+    private static final List<String> WITH_FROM = asList("InterPro:IPR015421", "InterPro:IPR015422");
+    private static final int INTERACTING_TAXON_ID = 35758;
+    private static final String ASSIGNED_BY = "InterPro";
+    private static final String SYMBOL = "moeA5";
 
     private AnnotationDocMocker() {
     }

--- a/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocMocker.java
+++ b/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocMocker.java
@@ -26,7 +26,7 @@ public class AnnotationDocMocker {
     public static final String GO_ID = "GO:0003824";
     public static final String ECO_ID = "ECO:0000256";
     public static final String REFERENCE = "GO_REF:0000002";
-    public static final int TAXON_ID = 12345;
+    public static final String TAXON_ID = "12345";
     public static final String GO_ASPECT = "cellular_component";
     public static final String EXTENSION_DB1 = "NCBI_gi";
     public static final String EXTENSION_DB2 = "Cl";
@@ -84,7 +84,7 @@ public class AnnotationDocMocker {
         doc.extensions = EXTENSIONS;
         doc.symbol = SYMBOL;
         doc.geneProductType = OBJECT_TYPE;
-        doc.taxonId = TAXON_ID;
+        doc.taxonId = Integer.parseInt(TAXON_ID);
         doc.taxonAncestors = TAXON_ANCESTORS;
         doc.targetSets = TARGET_SET;
         doc.geneProductSubset = GP_SUBSET;

--- a/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocMocker.java
+++ b/annotation-common/src/test/java/uk/ac/ebi/quickgo/annotation/common/document/AnnotationDocMocker.java
@@ -33,7 +33,7 @@ public class AnnotationDocMocker {
     private static final String ASSIGNED_BY = "InterPro";
     private static final String SYMBOL = "moeA5";
     private static final String OBJECT_TYPE = "protein";
-    private static final int TAXON_ID = 12345;
+    public static final int TAXON_ID = 12345;
     private static final List<Integer> TAXON_ANCESTORS = asList(12345, 1234, 123, 12, 1);
 
     private static final List<String> TARGET_SET = asList("KRUK", "BHF-UCL", "Exosome");

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationController.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationController.java
@@ -61,6 +61,12 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.http.HttpHeaders.ACCEPT;
 import static org.springframework.http.HttpHeaders.VARY;
 import static uk.ac.ebi.quickgo.annotation.download.http.MediaTypeFactory.*;
+import static uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.completablevalue
+        .EvidenceNameInjector.EVIDENCE_CODE;
+import static uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.completablevalue
+        .OntologyNameInjector.GO_ID;
+import static uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.completablevalue
+        .TaxonomyNameInjector.TAXON_ID;
 import static uk.ac.ebi.quickgo.rest.search.SearchDispatcher.searchAndTransform;
 import static uk.ac.ebi.quickgo.rest.search.SearchDispatcher.streamSearchResults;
 import static uk.ac.ebi.quickgo.rest.search.query.CursorPage.createFirstCursorPage;
@@ -325,9 +331,9 @@ public class AnnotationController {
     }
 
     private void addAllNamesToStatisticsValues(QueryResult<StatisticsGroup> stats) {
-        addNamesToStatisticsValues(stats, GO_NAME, OntologyNameInjector.GO_ID);
-        addNamesToStatisticsValues(stats, TAXON_NAME, TaxonomyNameInjector.TAXON_ID);
-        addNamesToStatisticsValues(stats, EVIDENCE_NAME, EvidenceNameInjector.EVIDENCE_CODE);
+        addNamesToStatisticsValues(stats, GO_NAME, GO_ID);
+        addNamesToStatisticsValues(stats, TAXON_NAME, TAXON_ID);
+        addNamesToStatisticsValues(stats, EVIDENCE_NAME, EVIDENCE_CODE);
     }
 
     private void checkBindingErrors(BindingResult bindingResult) {

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationController.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationController.java
@@ -479,7 +479,7 @@ public class AnnotationController {
                     .forEach(statisticsValue -> statisticsValue.setName(nameService.findName(nameField, statisticsValue
                             .getKey())));
         } catch (Exception e) {
-            LOGGER.error("Failed to retrieve GO names for StatisticsDownloadRequest", e);
+            LOGGER.error("Failed to retrieve name information processing statistics request", e);
         }
     }
 

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationController.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationController.java
@@ -319,15 +319,15 @@ public class AnnotationController {
                 .body(emitter);
     }
 
+    private static String formattedDateStringForNow() {
+        LocalDateTime now = LocalDateTime.now();
+        return now.format(DOWNLOAD_FILE_NAME_DATE_FORMATTER);
+    }
+
     private void addAllNamesToStatisticsValues(QueryResult<StatisticsGroup> stats) {
         addNamesToStatisticsValues(stats, GO_NAME, OntologyNameInjector.GO_ID);
         addNamesToStatisticsValues(stats, TAXON_NAME, TaxonomyNameInjector.TAXON_ID);
         addNamesToStatisticsValues(stats, EVIDENCE_NAME, EvidenceNameInjector.EVIDENCE_CODE);
-    }
-
-    private static String formattedDateStringForNow() {
-        LocalDateTime now = LocalDateTime.now();
-        return now.format(DOWNLOAD_FILE_NAME_DATE_FORMATTER);
     }
 
     private void checkBindingErrors(BindingResult bindingResult) {
@@ -479,6 +479,7 @@ public class AnnotationController {
 
     private interface FilterQueryInfo {
         Set<QuickGOQuery> getFilterQueries();
+
         FilterContext getFilterContext();
     }
 }

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/model/BasicOntology.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/model/BasicOntology.java
@@ -11,6 +11,12 @@ import java.util.List;
  *     <li>/go/terms/{term}</li>
  * </ul>
  *
+ * or
+ *
+ * <ul>
+ *     <li>/eco/terms/{term}</li>
+ * </ul>
+ *
  * This model captures the parts reached by the JSON path expression, "$.results.name".
  *
  * Created 07/04/17

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/transformer/completablevalue/EvidenceNameInjector.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/transformer/completablevalue/EvidenceNameInjector.java
@@ -1,0 +1,46 @@
+package uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.completablevalue;
+
+import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.BasicOntology;
+import uk.ac.ebi.quickgo.rest.model.CompletableValue;
+import uk.ac.ebi.quickgo.rest.search.request.FilterRequest;
+import uk.ac.ebi.quickgo.rest.search.request.converter.ConvertedFilter;
+import uk.ac.ebi.quickgo.rest.search.results.transformer.AbstractValueInjector;
+
+import java.util.List;
+
+/**
+ * This class is responsible for supplementing an {@link CompletableValue} instance, which contains
+ * an ECO code (in the key field), with a ECO name, through the use of a RESTful service.
+ *
+ * Created 11/12/17
+ * @author Tony Wardell
+ */
+public class EvidenceNameInjector extends AbstractValueInjector<BasicOntology, CompletableValue> {
+
+    public static final String EVIDENCE_CODE = "evidenceCode";
+    private static final String EVIDENCE_NAME = "evidenceName";
+
+    @Override
+    public String getId() {
+        return EVIDENCE_NAME;
+    }
+
+    @Override
+    public FilterRequest buildFilterRequest(CompletableValue completableValue) {
+        return FilterRequest.newBuilder()
+                .addProperty(getId())
+                .addProperty(EVIDENCE_CODE, completableValue.getKey())
+                .build();
+    }
+
+    @Override
+    public void injectValueFromResponse(ConvertedFilter<BasicOntology> convertedRequest,
+            CompletableValue completableValue) {
+        BasicOntology response = convertedRequest.getConvertedValue();
+
+        List<BasicOntology.Result> results = response.getResults();
+        if (!results.isEmpty()) {
+            completableValue.setValue(results.get(0).getName());
+        }
+    }
+}

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/search/SearchServiceConfig.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/search/SearchServiceConfig.java
@@ -251,16 +251,13 @@ public class SearchServiceConfig {
 
     @Bean
     public ResultTransformerChain<CompletableValue> completableValueResultTransformerChain(
-            ExternalServiceResultsTransformer<CompletableValue, CompletableValue>
-                    completableValueOntologyNameTransformer,
-            ExternalServiceResultsTransformer<CompletableValue, CompletableValue>
-                    completableValueTaxonNameTransformer,
-            ExternalServiceResultsTransformer<CompletableValue, CompletableValue>
-                    completableValueEvidenceNameTransformer) {
+            ExternalServiceResultsTransformer<CompletableValue, CompletableValue> ontologyNameTransformer,
+            ExternalServiceResultsTransformer<CompletableValue, CompletableValue> taxonNameTransformer,
+            ExternalServiceResultsTransformer<CompletableValue, CompletableValue> evidenceNameTransformer) {
         ResultTransformerChain<CompletableValue> transformerChain = new ResultTransformerChain<>();
-        transformerChain.addTransformer(completableValueOntologyNameTransformer);
-        transformerChain.addTransformer(completableValueTaxonNameTransformer);
-        transformerChain.addTransformer(completableValueEvidenceNameTransformer);
+        transformerChain.addTransformer(ontologyNameTransformer);
+        transformerChain.addTransformer(taxonNameTransformer);
+        transformerChain.addTransformer(evidenceNameTransformer);
         return transformerChain;
     }
 
@@ -294,7 +291,7 @@ public class SearchServiceConfig {
     }
 
     @Bean
-    public ExternalServiceResultsTransformer<CompletableValue, CompletableValue> completableValueOntologyNameTransformer
+    public ExternalServiceResultsTransformer<CompletableValue, CompletableValue> ontologyNameTransformer
             (RESTFilterConverterFactory converterFactory) {
         List<ResponseValueInjector<CompletableValue>> responseValueInjectors =
                 singletonList(new uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer
@@ -310,7 +307,7 @@ public class SearchServiceConfig {
     }
 
     @Bean
-    public ExternalServiceResultsTransformer<CompletableValue, CompletableValue> completableValueTaxonNameTransformer
+    public ExternalServiceResultsTransformer<CompletableValue, CompletableValue> taxonNameTransformer
             (RESTFilterConverterFactory converterFactory) {
         List<ResponseValueInjector<CompletableValue>> responseValueInjectors = singletonList(
                 new uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.completablevalue
@@ -320,7 +317,7 @@ public class SearchServiceConfig {
     }
 
     @Bean
-    public ExternalServiceResultsTransformer<CompletableValue, CompletableValue> completableValueEvidenceNameTransformer
+    public ExternalServiceResultsTransformer<CompletableValue, CompletableValue> evidenceNameTransformer
             (RESTFilterConverterFactory converterFactory) {
         List<ResponseValueInjector<CompletableValue>> responseValueInjectors = singletonList(
                 new EvidenceNameInjector());

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/search/SearchServiceConfig.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/search/SearchServiceConfig.java
@@ -8,6 +8,7 @@ import uk.ac.ebi.quickgo.annotation.service.comm.rest.geneproduct.transformer.Ge
 import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.annotation.OntologyNameInjector;
 import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.annotation.SlimResultsTransformer;
 import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.annotation.TaxonomyNameInjector;
+import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.completablevalue.EvidenceNameInjector;
 import uk.ac.ebi.quickgo.annotation.service.converter.AnnotationDocConverterImpl;
 import uk.ac.ebi.quickgo.common.SearchableField;
 import uk.ac.ebi.quickgo.common.loader.DbXRefLoader;
@@ -262,10 +263,13 @@ public class SearchServiceConfig {
             ExternalServiceResultsTransformer<CompletableValue, CompletableValue>
                     completableValueOntologyNameTransformer,
             ExternalServiceResultsTransformer<CompletableValue, CompletableValue>
-                    completableValueTaxonNameTransformer) {
+                    completableValueTaxonNameTransformer,
+            ExternalServiceResultsTransformer<CompletableValue, CompletableValue>
+                    completableValueEvidenceNameTransformer) {
         ResultTransformerChain<CompletableValue> transformerChain = new ResultTransformerChain<>();
         transformerChain.addTransformer(completableValueOntologyNameTransformer);
         transformerChain.addTransformer(completableValueTaxonNameTransformer);
+        transformerChain.addTransformer(completableValueEvidenceNameTransformer);
         return transformerChain;
     }
 
@@ -320,6 +324,15 @@ public class SearchServiceConfig {
         List<ResponseValueInjector<CompletableValue>> responseValueInjectors = singletonList(
                 new uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.completablevalue
                         .TaxonomyNameInjector());
+        return new ExternalServiceResultsTransformer<>(responseValueInjectors,
+                completableValueResultMutator(converterFactory));
+    }
+
+    @Bean
+    public ExternalServiceResultsTransformer<CompletableValue, CompletableValue> completableValueEvidenceNameTransformer
+            (RESTFilterConverterFactory converterFactory) {
+        List<ResponseValueInjector<CompletableValue>> responseValueInjectors = singletonList(
+                new EvidenceNameInjector());
         return new ExternalServiceResultsTransformer<>(responseValueInjectors,
                 completableValueResultMutator(converterFactory));
     }

--- a/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/search/SearchServiceConfig.java
+++ b/annotation-rest/src/main/java/uk/ac/ebi/quickgo/annotation/service/search/SearchServiceConfig.java
@@ -220,11 +220,6 @@ public class SearchServiceConfig {
         return new ExternalServiceResultsTransformer<>(responseValueInjectors, queryResultMutator(converterFactory));
     }
 
-    private ValueInjectionToQueryResults<Annotation> queryResultMutator(
-            RESTFilterConverterFactory converterFactory) {
-        return new ValueInjectionToQueryResults<>(converterFactory);
-    }
-
     @Bean
     public ExternalServiceResultsTransformer<QueryResult<Annotation>, Annotation> geneProductResultsTransformer
             (RESTFilterConverterFactory converterFactory) {
@@ -237,10 +232,6 @@ public class SearchServiceConfig {
     @Bean
     public DbXRefEntityValidation geneProductValidator() {
         return DbXRefEntityValidation.createWithData(geneProductLoader().load());
-    }
-
-    private DbXRefLoader geneProductLoader() {
-        return new DbXRefLoader(this.xrefValidationRegexFile, xrefValidationCaseSensitive);
     }
 
     @Bean
@@ -335,6 +326,15 @@ public class SearchServiceConfig {
                 new EvidenceNameInjector());
         return new ExternalServiceResultsTransformer<>(responseValueInjectors,
                 completableValueResultMutator(converterFactory));
+    }
+
+    private ValueInjectionToQueryResults<Annotation> queryResultMutator(
+            RESTFilterConverterFactory converterFactory) {
+        return new ValueInjectionToQueryResults<>(converterFactory);
+    }
+
+    private DbXRefLoader geneProductLoader() {
+        return new DbXRefLoader(this.xrefValidationRegexFile, xrefValidationCaseSensitive);
     }
 
     public interface AnnotationCompositeRetrievalConfig extends SolrRetrievalConfig, ServiceRetrievalConfig {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
@@ -102,9 +102,7 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     @Test
     public void canDownloadInExcelFormat() throws Exception {
-        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS);
-        setupHelper.expectTaxonIdHasNameViaRest(TAXON_ID, TAXON_NAME);
-        setupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, NUMBER_OF_GENERIC_DOCS);
+        setupSuccessfullyReceivingRestNames();
 
         ResultActions response = mockMvc.perform(get(DOWNLOAD_STATISTICS_SEARCH_URL).header(ACCEPT, EXCEL_MEDIA_TYPE));
 
@@ -113,9 +111,7 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     @Test
     public void canDownloadInJsonFormat() throws Exception {
-        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS);
-        setupHelper.expectTaxonIdHasNameViaRest(TAXON_ID, TAXON_NAME);
-        setupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, NUMBER_OF_GENERIC_DOCS);
+        setupSuccessfullyReceivingRestNames();
 
         ResultActions response = mockMvc.perform(get(DOWNLOAD_STATISTICS_SEARCH_URL).header(ACCEPT, JSON_MEDIA_TYPE));
 
@@ -189,6 +185,12 @@ public class AnnotationControllerStatisticsDownloadIT {
                 .andExpect(namesInTypeWithinGroup(GENE_PRODUCT_GROUP, TAXON_ID_STATS_FIELD, new String[]{TAXON_NAME}))
                 .andExpect(namesInTypeWithinGroup(ANNOTATION_GROUP, EVIDENCE_CODE_STATS_FIELD, new String[]{null}))
                 .andExpect(namesInTypeWithinGroup(GENE_PRODUCT_GROUP, EVIDENCE_CODE_STATS_FIELD, new String[]{null}));
+    }
+
+    private void setupSuccessfullyReceivingRestNames() {
+        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS);
+        setupHelper.expectTaxonIdHasNameViaRest(TAXON_ID, TAXON_NAME);
+        setupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, NUMBER_OF_GENERIC_DOCS);
     }
 
     private void setExpectationsForUnsuccessfulOntologyServiceRestResponse() {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
@@ -115,11 +115,11 @@ public class AnnotationControllerStatisticsDownloadIT {
         goNames = new String[NUMBER_OF_GENERIC_DOCS];
         IntStream.range(0, goNames.length)
                 .forEach(i -> goNames[i] = goName(i));
+        cacheManager.clearAll();
     }
 
     @Test
     public void canDownloadInExcelFormat() throws Exception {
-        cacheManager.clearAll();
         setExpectationsForSuccessfulOntologyServiceRestResponse();
         setExpectationsForSuccessfulTaxonomyServiceRestResponse();
         setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes();
@@ -131,7 +131,6 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     @Test
     public void canDownloadInJsonFormat() throws Exception {
-        cacheManager.clearAll();
         setExpectationsForSuccessfulOntologyServiceRestResponse();
         setExpectationsForSuccessfulTaxonomyServiceRestResponse();
         setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes();
@@ -152,7 +151,6 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     @Test
     public void downloadStatisticsSuccessfulAfterFailedToRetrieveGONames() throws Exception {
-        cacheManager.clearAll();
         setExpectationsForUnsuccessfulOntologyServiceRestResponse();
         setExpectationsForSuccessfulTaxonomyServiceRestResponse();
         setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes();
@@ -175,7 +173,6 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     @Test
     public void downloadStatisticsSuccessfulAfterFailedToRetrieveTaxonNames() throws Exception {
-        cacheManager.clearAll();
         setExpectationsForSuccessfulOntologyServiceRestResponse();
         setExpectationsForUnsuccessfulTaxonomyServiceRestResponse();
         setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes();
@@ -196,7 +193,6 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     @Test
     public void downloadStatisticsSuccessfulAfterFailedToRetrieveECONames() throws Exception {
-        cacheManager.clearAll();
         setExpectationsForSuccessfulOntologyServiceRestResponse();
         setExpectationsForSuccessfulTaxonomyServiceRestResponse();
         setExpectationsForUnsuccessfulOntologyServiceRestResponseForEcoCodes();

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
@@ -1,11 +1,13 @@
 package uk.ac.ebi.quickgo.annotation.controller;
 
 import uk.ac.ebi.quickgo.annotation.AnnotationREST;
+import uk.ac.ebi.quickgo.annotation.IdGeneratorUtil;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationRepository;
 import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 import net.sf.ehcache.CacheManager;
 import org.junit.Before;
@@ -70,6 +72,8 @@ public class AnnotationControllerStatisticsDownloadIT {
     private static final String GO_ID_STATS_FIELD = "goId";
     private static final String TAXON_NAME = "taxon name: " + 12345;
     private static final String TAXON_ID = "12345";
+    private static final Function<Integer, String> toId = i -> IdGeneratorUtil.createGoId(i);
+    private static final Function<Integer, String> toName = i -> IdGeneratorUtil.createGoId(i) + " name";
 
     @Autowired
     CacheManager cacheManager;
@@ -93,7 +97,7 @@ public class AnnotationControllerStatisticsDownloadIT {
         setupHelper = new StatsSetupHelper(mockRestServiceServer);
         goNames = new String[NUMBER_OF_GENERIC_DOCS];
         IntStream.range(0, goNames.length)
-                .forEach(i -> goNames[i] = setupHelper.goName(i));
+                .forEach(i -> goNames[i] = toName.apply(i));
         cacheManager.clearAll();
     }
 
@@ -148,7 +152,7 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     @Test
     public void downloadStatisticsSuccessfulAfterFailedToRetrieveTaxonNames() throws Exception {
-        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS);
+        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS, toId, toName);
         setExpectationsForUnsuccessfulTaxonomyServiceRestResponse();
         setupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, NUMBER_OF_GENERIC_DOCS);
 
@@ -168,7 +172,7 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     @Test
     public void downloadStatisticsSuccessfulAfterFailedToRetrieveECONames() throws Exception {
-        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS);
+        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS, toId, toName);
         setupHelper.expectTaxonIdHasNameViaRest(TAXON_ID, TAXON_NAME);
         setExpectationsForUnsuccessfulOntologyServiceRestResponseForEcoCodes();
 
@@ -185,14 +189,14 @@ public class AnnotationControllerStatisticsDownloadIT {
     }
 
     private void setupSuccessfullyReceivingRestNames() {
-        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS);
+        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS, toId, toName);
         setupHelper.expectTaxonIdHasNameViaRest(TAXON_ID, TAXON_NAME);
         setupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, NUMBER_OF_GENERIC_DOCS);
     }
 
     private void setExpectationsForUnsuccessfulOntologyServiceRestResponse() {
         for (int k = 0; k < NO_OF_STATISTICS_GROUPS; k++) {
-            setupHelper.expectFailureToGetNameForGoTermViaRest(NUMBER_OF_GENERIC_DOCS);
+            setupHelper.expectFailureToGetNameForGoTermViaRest(NUMBER_OF_GENERIC_DOCS, toId);
         }
     }
 

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
@@ -1,14 +1,10 @@
 package uk.ac.ebi.quickgo.annotation.controller;
 
 import uk.ac.ebi.quickgo.annotation.AnnotationREST;
-import uk.ac.ebi.quickgo.annotation.IdGeneratorUtil;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationDocument;
 import uk.ac.ebi.quickgo.annotation.common.AnnotationRepository;
-import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.BasicTaxonomyNode;
 import uk.ac.ebi.quickgo.common.store.TemporarySolrDataStore;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.stream.IntStream;
 import net.sf.ehcache.CacheManager;
@@ -31,8 +27,6 @@ import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.WebApplicationContext;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.HttpHeaders.ACCEPT;
@@ -70,7 +64,6 @@ public class AnnotationControllerStatisticsDownloadIT {
     private static final String NUMBER_OF_GO_ID_RESULTS_FOR_ANNOTATIONS =
             "$.results[0].types.[?(@.type == 'goId')].values.length()";
     private static final String ECO_TERM_NAME = "match to sequence model evidence used in automatic assertion";
-    private static final String TAXONOMY_ID_NODE_RESOURCE_FORMAT = "/proteins/api/taxonomy/id/%s/node";
     private static final int NO_OF_STATISTICS_GROUPS = 2;
     private static final String ANNOTATION_GROUP = "annotation";
     private static final String GENE_PRODUCT_GROUP = "geneProduct";
@@ -78,7 +71,7 @@ public class AnnotationControllerStatisticsDownloadIT {
     private static final String EVIDENCE_CODE_STATS_FIELD = "evidenceCode";
     private static final String GO_ID_STATS_FIELD = "goId";
     private static final String TAXON_NAME = "taxon name: " + 12345;
-    private static final int TAXON_ID = 12345;
+    private static final String TAXON_ID = "12345";
 
     @Autowired
     CacheManager cacheManager;
@@ -90,30 +83,28 @@ public class AnnotationControllerStatisticsDownloadIT {
     @Autowired
     private RestOperations restOperations;
     private MockRestServiceServer mockRestServiceServer;
-    private ObjectMapper dtoMapper;
     private String[] goNames;
-    private StatsSetupHelper statsSetupHelper;
+    private StatsSetupHelper setupHelper;
 
     @Before
     public void setup() {
         annotationRepository.deleteAll();
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
         mockRestServiceServer = MockRestServiceServer.createServer((RestTemplate) restOperations);
-        dtoMapper = new ObjectMapper();
         List<AnnotationDocument> genericDocs = createGenericDocsChangingGoId(NUMBER_OF_GENERIC_DOCS);
         annotationRepository.save(genericDocs);
-        statsSetupHelper = new StatsSetupHelper(mockRestServiceServer);
+        setupHelper = new StatsSetupHelper(mockRestServiceServer);
         goNames = new String[NUMBER_OF_GENERIC_DOCS];
         IntStream.range(0, goNames.length)
-                .forEach(i -> goNames[i] = goName(i));
+                .forEach(i -> goNames[i] = setupHelper.goName(i));
         cacheManager.clearAll();
     }
 
     @Test
     public void canDownloadInExcelFormat() throws Exception {
-        setExpectationsForSuccessfulOntologyServiceRestResponse();
-        setExpectationsForSuccessfulTaxonomyServiceRestResponse();
-        setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes();
+        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS);
+        setupHelper.expectTaxonIdHasNameViaRest(TAXON_ID, TAXON_NAME);
+        setupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, NUMBER_OF_GENERIC_DOCS);
 
         ResultActions response = mockMvc.perform(get(DOWNLOAD_STATISTICS_SEARCH_URL).header(ACCEPT, EXCEL_MEDIA_TYPE));
 
@@ -122,9 +113,9 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     @Test
     public void canDownloadInJsonFormat() throws Exception {
-        setExpectationsForSuccessfulOntologyServiceRestResponse();
-        setExpectationsForSuccessfulTaxonomyServiceRestResponse();
-        setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes();
+        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS);
+        setupHelper.expectTaxonIdHasNameViaRest(TAXON_ID, TAXON_NAME);
+        setupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, NUMBER_OF_GENERIC_DOCS);
 
         ResultActions response = mockMvc.perform(get(DOWNLOAD_STATISTICS_SEARCH_URL).header(ACCEPT, JSON_MEDIA_TYPE));
 
@@ -143,8 +134,8 @@ public class AnnotationControllerStatisticsDownloadIT {
     @Test
     public void downloadStatisticsSuccessfulAfterFailedToRetrieveGONames() throws Exception {
         setExpectationsForUnsuccessfulOntologyServiceRestResponse();
-        setExpectationsForSuccessfulTaxonomyServiceRestResponse();
-        setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes();
+        setupHelper.expectTaxonIdHasNameViaRest(TAXON_ID, TAXON_NAME);
+        setupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, NUMBER_OF_GENERIC_DOCS);
 
         ResultActions response = mockMvc.perform(get(DOWNLOAD_STATISTICS_SEARCH_URL).header(ACCEPT, JSON_MEDIA_TYPE));
 
@@ -164,9 +155,9 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     @Test
     public void downloadStatisticsSuccessfulAfterFailedToRetrieveTaxonNames() throws Exception {
-        setExpectationsForSuccessfulOntologyServiceRestResponse();
+        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS);
         setExpectationsForUnsuccessfulTaxonomyServiceRestResponse();
-        setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes();
+        setupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, NUMBER_OF_GENERIC_DOCS);
 
         ResultActions response = mockMvc.perform(get(DOWNLOAD_STATISTICS_SEARCH_URL).header(ACCEPT, JSON_MEDIA_TYPE));
 
@@ -184,8 +175,8 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     @Test
     public void downloadStatisticsSuccessfulAfterFailedToRetrieveECONames() throws Exception {
-        setExpectationsForSuccessfulOntologyServiceRestResponse();
-        setExpectationsForSuccessfulTaxonomyServiceRestResponse();
+        setupHelper.expectGoTermHasNameViaRest(NUMBER_OF_GENERIC_DOCS);
+        setupHelper.expectTaxonIdHasNameViaRest(TAXON_ID, TAXON_NAME);
         setExpectationsForUnsuccessfulOntologyServiceRestResponseForEcoCodes();
 
         ResultActions response = mockMvc.perform(get(DOWNLOAD_STATISTICS_SEARCH_URL).header(ACCEPT, JSON_MEDIA_TYPE));
@@ -200,41 +191,10 @@ public class AnnotationControllerStatisticsDownloadIT {
                 .andExpect(namesInTypeWithinGroup(GENE_PRODUCT_GROUP, EVIDENCE_CODE_STATS_FIELD, new String[]{null}));
     }
 
-    private String goId(int id) {
-        return IdGeneratorUtil.createGoId(id);
-    }
-
-    private void expectTaxonIdHasGivenTaxonNameViaRest(int taxonId, String taxonName) {
-        checkArgument(taxonName != null && !taxonName.isEmpty(), "taxonName cannot be null or empty");
-
-        BasicTaxonomyNode expectedResponse = new BasicTaxonomyNode();
-        expectedResponse.setScientificName(taxonName);
-        String responseAsString = getResponseAsString(expectedResponse);
-
-        statsSetupHelper.expectRestCallSuccess(
-                statsSetupHelper.buildResource(
-                        TAXONOMY_ID_NODE_RESOURCE_FORMAT,
-                        String.valueOf(taxonId)),
-                responseAsString);
-    }
-
-    private <T> String getResponseAsString(T response) {
-        try {
-            return dtoMapper.writeValueAsString(response);
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Problem constructing mocked GO term REST response:", e);
-        }
-    }
-
-    private void checkResponse(ResultActions response, int expectedSize) throws Exception {
-        checkResponse(JSON_MEDIA_TYPE, response);
-        response.andExpect(numOfResults(NUMBER_OF_GO_ID_RESULTS_FOR_ANNOTATIONS, expectedSize));
-    }
-
     private void setExpectationsForUnsuccessfulOntologyServiceRestResponse() {
         for (int k = 0; k < NO_OF_STATISTICS_GROUPS; k++) {
             for (int j = 0; j < NUMBER_OF_GENERIC_DOCS; j++) {
-                statsSetupHelper.expectGORestCallResponse(goId(j), withStatus(HttpStatus
+                setupHelper.expectGORestCallResponse(setupHelper.goId(j), withStatus(HttpStatus
                         .NOT_FOUND));
             }
         }
@@ -242,38 +202,20 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     private void setExpectationsForUnsuccessfulTaxonomyServiceRestResponse() {
         for (int i = 0; i < NO_OF_STATISTICS_GROUPS; i++) {
-            statsSetupHelper.expectTaxonomyRestCallResponse(String.valueOf(TAXON_ID),
+            setupHelper.expectTaxonomyRestCallResponse(String.valueOf(TAXON_ID),
                     withStatus(HttpStatus.NOT_FOUND));
-        }
-    }
-
-    private String goName(int id) {
-        return IdGeneratorUtil.createGoId(id) + " name";
-    }
-
-    private void setExpectationsForSuccessfulOntologyServiceRestResponse() {
-        //Hitting the cache means that the call to the rest service will occur only once for each term to get term name
-        for (int j = 0; j < NUMBER_OF_GENERIC_DOCS; j++) {
-            expectGoTermsHaveGoNamesViaRest(singletonList(goId(j)), singletonList(goName(j)));
-        }
-    }
-
-    private void setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes() {
-        //Hitting the cache means that the call to the rest service will occur only once for each term to get term name
-        for (int j = 0; j < NUMBER_OF_GENERIC_DOCS; j++) {
-            statsSetupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME);
         }
     }
 
     private void setExpectationsForUnsuccessfulOntologyServiceRestResponseForEcoCodes() {
         for (int i = 0; i < NO_OF_STATISTICS_GROUPS; i++) {
-            statsSetupHelper.expectEcoRestCallResponse(ECO_ID, withStatus(HttpStatus.NOT_FOUND));
+            setupHelper.expectEcoRestCallResponse(ECO_ID, withStatus(HttpStatus.NOT_FOUND));
         }
     }
 
-    private void setExpectationsForSuccessfulTaxonomyServiceRestResponse() {
-        //We are only going to hit the restful service once due to caching the result
-        expectTaxonIdHasGivenTaxonNameViaRest(TAXON_ID, TAXON_NAME);
+    private void checkResponse(ResultActions response, int expectedSize) throws Exception {
+        checkResponse(JSON_MEDIA_TYPE, response);
+        response.andExpect(numOfResults(NUMBER_OF_GO_ID_RESULTS_FOR_ANNOTATIONS, expectedSize));
     }
 
     private void checkResponse(MediaType mediaType, ResultActions response) throws Exception {
@@ -283,13 +225,5 @@ public class AnnotationControllerStatisticsDownloadIT {
                 .andExpect(header().string(VARY, is(ACCEPT)))
                 .andExpect(header().string(CONTENT_DISPOSITION, endsWith("." + fileExtension(mediaType) + "\"")))
                 .andExpect(content().contentType(mediaType));
-    }
-
-    private void expectGoTermsHaveGoNamesViaRest(List<String> termIds, List<String> termNames) {
-        for (int i = 0; i < termIds.size(); i++) {
-            String termId = termIds.get(i);
-            String termName = termNames.get(i);
-            statsSetupHelper.expectGoTermHasNameViaRest(termId, termName);
-        }
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
@@ -194,16 +194,14 @@ public class AnnotationControllerStatisticsDownloadIT {
     private void setExpectationsForUnsuccessfulOntologyServiceRestResponse() {
         for (int k = 0; k < NO_OF_STATISTICS_GROUPS; k++) {
             for (int j = 0; j < NUMBER_OF_GENERIC_DOCS; j++) {
-                setupHelper.expectGORestCallResponse(setupHelper.goId(j), withStatus(HttpStatus
-                        .NOT_FOUND));
+                setupHelper.expectGORestCallResponse(setupHelper.goId(j), withStatus(HttpStatus.NOT_FOUND));
             }
         }
     }
 
     private void setExpectationsForUnsuccessfulTaxonomyServiceRestResponse() {
         for (int i = 0; i < NO_OF_STATISTICS_GROUPS; i++) {
-            setupHelper.expectTaxonomyRestCallResponse(String.valueOf(TAXON_ID),
-                    withStatus(HttpStatus.NOT_FOUND));
+            setupHelper.expectTaxonomyRestCallResponse(String.valueOf(TAXON_ID), withStatus(HttpStatus.NOT_FOUND));
         }
     }
 

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
@@ -201,15 +201,11 @@ public class AnnotationControllerStatisticsDownloadIT {
     }
 
     private void setExpectationsForUnsuccessfulTaxonomyServiceRestResponse() {
-        for (int i = 0; i < NO_OF_STATISTICS_GROUPS; i++) {
-            setupHelper.expectFailureToGetTaxonomyNameViaRest(TAXON_ID);
-        }
+        setupHelper.expectFailureToGetTaxonomyNameViaRest(TAXON_ID, NO_OF_STATISTICS_GROUPS);
     }
 
     private void setExpectationsForUnsuccessfulOntologyServiceRestResponseForEcoCodes() {
-        for (int i = 0; i < NO_OF_STATISTICS_GROUPS; i++) {
-            setupHelper.expectFailureToGetEcoNameViaRest(ECO_ID);
-        }
+        setupHelper.expectFailureToGetEcoNameViaRest(ECO_ID, NO_OF_STATISTICS_GROUPS);
     }
 
     private void checkResponse(ResultActions response) throws Exception {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsDownloadIT.java
@@ -102,7 +102,7 @@ public class AnnotationControllerStatisticsDownloadIT {
         dtoMapper = new ObjectMapper();
         List<AnnotationDocument> genericDocs = createGenericDocsChangingGoId(NUMBER_OF_GENERIC_DOCS);
         annotationRepository.save(genericDocs);
-        statsSetupHelper = new StatsSetupHelper();
+        statsSetupHelper = new StatsSetupHelper(mockRestServiceServer);
         goNames = new String[NUMBER_OF_GENERIC_DOCS];
         IntStream.range(0, goNames.length)
                 .forEach(i -> goNames[i] = goName(i));
@@ -211,7 +211,7 @@ public class AnnotationControllerStatisticsDownloadIT {
         expectedResponse.setScientificName(taxonName);
         String responseAsString = getResponseAsString(expectedResponse);
 
-        statsSetupHelper.expectRestCallSuccess(mockRestServiceServer,
+        statsSetupHelper.expectRestCallSuccess(
                 statsSetupHelper.buildResource(
                         TAXONOMY_ID_NODE_RESOURCE_FORMAT,
                         String.valueOf(taxonId)),
@@ -234,7 +234,7 @@ public class AnnotationControllerStatisticsDownloadIT {
     private void setExpectationsForUnsuccessfulOntologyServiceRestResponse() {
         for (int k = 0; k < NO_OF_STATISTICS_GROUPS; k++) {
             for (int j = 0; j < NUMBER_OF_GENERIC_DOCS; j++) {
-                statsSetupHelper.expectGORestCallResponse(mockRestServiceServer, goId(j), withStatus(HttpStatus
+                statsSetupHelper.expectGORestCallResponse(goId(j), withStatus(HttpStatus
                         .NOT_FOUND));
             }
         }
@@ -242,7 +242,7 @@ public class AnnotationControllerStatisticsDownloadIT {
 
     private void setExpectationsForUnsuccessfulTaxonomyServiceRestResponse() {
         for (int i = 0; i < NO_OF_STATISTICS_GROUPS; i++) {
-            statsSetupHelper.expectTaxonomyRestCallResponse(mockRestServiceServer, String.valueOf(TAXON_ID),
+            statsSetupHelper.expectTaxonomyRestCallResponse(String.valueOf(TAXON_ID),
                     withStatus(HttpStatus.NOT_FOUND));
         }
     }
@@ -261,13 +261,13 @@ public class AnnotationControllerStatisticsDownloadIT {
     private void setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes() {
         //Hitting the cache means that the call to the rest service will occur only once for each term to get term name
         for (int j = 0; j < NUMBER_OF_GENERIC_DOCS; j++) {
-            statsSetupHelper.expectEcoCodeHasNameViaRest(mockRestServiceServer, ECO_ID, ECO_TERM_NAME);
+            statsSetupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME);
         }
     }
 
     private void setExpectationsForUnsuccessfulOntologyServiceRestResponseForEcoCodes() {
         for (int i = 0; i < NO_OF_STATISTICS_GROUPS; i++) {
-            statsSetupHelper.expectEcoRestCallResponse(mockRestServiceServer, ECO_ID, withStatus(HttpStatus.NOT_FOUND));
+            statsSetupHelper.expectEcoRestCallResponse(ECO_ID, withStatus(HttpStatus.NOT_FOUND));
         }
     }
 
@@ -289,7 +289,7 @@ public class AnnotationControllerStatisticsDownloadIT {
         for (int i = 0; i < termIds.size(); i++) {
             String termId = termIds.get(i);
             String termName = termNames.get(i);
-            statsSetupHelper.expectGoTermHasNameViaRest(mockRestServiceServer, termId, termName);
+            statsSetupHelper.expectGoTermHasNameViaRest(termId, termName);
         }
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
@@ -39,9 +39,6 @@ import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.GO_USAGE_PARAM;
 import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.TAXON_ID_PARAM;
 import static uk.ac.ebi.quickgo.annotation.AnnotationParameters.TAXON_USAGE_PARAM;
 import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationDocMocker.*;
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationDocMocker.ECO_ID;
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationDocMocker.GO_ID;
-import static uk.ac.ebi.quickgo.annotation.common.document.AnnotationDocMocker.TAXON_ID;
 import static uk.ac.ebi.quickgo.annotation.controller.ResponseVerifier.contentTypeToBeJson;
 import static uk.ac.ebi.quickgo.annotation.controller.ResponseVerifier.totalNumOfResults;
 import static uk.ac.ebi.quickgo.annotation.controller.StatsResponseVerifier.keysInTypeWithinGroup;
@@ -105,7 +102,7 @@ public class AnnotationControllerStatisticsIT {
                 webAppContextSetup(webApplicationContext)
                 .build();
         mockRestServiceServer = MockRestServiceServer.createServer((RestTemplate) restOperations);
-        savedDocs = createGenericDocs(NUMBER_OF_GENERIC_DOCS);
+        savedDocs = createGenericDocs();
         repository.save(savedDocs);
     }
 
@@ -456,8 +453,8 @@ public class AnnotationControllerStatisticsIT {
         return elements.toArray(new String[0]);
     }
 
-    private List<AnnotationDocument> createGenericDocs(int n) {
-        return IntStream.range(0, n)
+    private List<AnnotationDocument> createGenericDocs() {
+        return IntStream.range(0, AnnotationControllerStatisticsIT.NUMBER_OF_GENERIC_DOCS)
                 .mapToObj(i -> createAnnotationDoc(createId(i)))
                 .collect(Collectors.toList());
     }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
@@ -183,9 +183,10 @@ public class AnnotationControllerStatisticsIT {
     public void namesForGoIdsAndTaxonIdsAndEvidenceCodes() throws Exception {
         cacheManager.clearAll();
         final int expectedDistinctValueCount = 1;
-        setExpectationsForSuccessfulOntologyServiceRestResponse(expectedDistinctValueCount);
-        setExpectationsForSuccessfulTaxonomyServiceRestResponse(expectedDistinctValueCount);
-        setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes(expectedDistinctValueCount);
+
+        expectGoTermsHaveGoNamesViaRest();
+        expectTaxonIdHasGivenTaxonNameViaRest();
+        expectEcoCodeHasGivenEcoNameViaRest();
 
         assertStatsResponseIncludingNames(expectedDistinctValueCount);
     }
@@ -479,24 +480,6 @@ public class AnnotationControllerStatisticsIT {
 
     private String createId(int idNum) {
         return String.format("A0A%03d", idNum);
-    }
-
-    private void setExpectationsForSuccessfulOntologyServiceRestResponse(int expectedNumber) {
-        for (int i = 0; i < expectedNumber; i++) {
-            expectGoTermsHaveGoNamesViaRest();
-        }
-    }
-
-    private void setExpectationsForSuccessfulTaxonomyServiceRestResponse(int expectedNumber) {
-        for (int i = 0; i < expectedNumber; i++) {
-            expectTaxonIdHasGivenTaxonNameViaRest();
-        }
-    }
-
-    private void setExpectationsForSuccessfulOntologyServiceRestResponseForEcoCodes(int expectedNumber) {
-        for (int i = 0; i < expectedNumber; i++) {
-            expectEcoCodeHasGivenEcoNameViaRest();
-        }
     }
 
     private void expectGoTermsHaveGoNamesViaRest() {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
@@ -169,7 +169,7 @@ public class AnnotationControllerStatisticsIT {
         final int expectedDistinctValueCount = 1;
         StatsSetupHelper statsSetupHelper = new StatsSetupHelper(mockRestServiceServer);
         statsSetupHelper.expectGoTermHasNameViaRest(GO_ID, GO_TERM_NAME);
-        statsSetupHelper.expectTaxonIdHasNameViaRest(String.valueOf(TAXON_ID), TAXON_NAME);
+        statsSetupHelper.expectTaxonIdHasNameViaRest(TAXON_ID, TAXON_NAME);
         statsSetupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, expectedDistinctValueCount);
 
         assertStatsResponseIncludingNames(expectedDistinctValueCount);

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
@@ -97,8 +97,6 @@ public class AnnotationControllerStatisticsIT {
     @Autowired
     private AnnotationRepository repository;
 
-    private StatsSetupHelper statsSetupHelper;
-
     @Before
     public void setup() {
         repository.deleteAll();
@@ -109,7 +107,6 @@ public class AnnotationControllerStatisticsIT {
         mockRestServiceServer = MockRestServiceServer.createServer((RestTemplate) restOperations);
         savedDocs = createGenericDocs(NUMBER_OF_GENERIC_DOCS);
         repository.save(savedDocs);
-        statsSetupHelper = new StatsSetupHelper(mockRestServiceServer);
     }
 
     @Test
@@ -170,7 +167,7 @@ public class AnnotationControllerStatisticsIT {
     public void namesForGoIdsAndTaxonIdsAndEvidenceCodes() throws Exception {
         cacheManager.clearAll();
         final int expectedDistinctValueCount = 1;
-
+        StatsSetupHelper statsSetupHelper = new StatsSetupHelper(mockRestServiceServer);
         statsSetupHelper.expectGoTermHasNameViaRest(GO_ID, GO_TERM_NAME);
         statsSetupHelper.expectTaxonIdHasNameViaRest(String.valueOf(TAXON_ID), TAXON_NAME);
         statsSetupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, expectedDistinctValueCount);
@@ -442,9 +439,9 @@ public class AnnotationControllerStatisticsIT {
     private void assertStatsResponseIncludingNames(int expectedDistinctValueCount) throws Exception {
         ResultActions response = mockMvc.perform(get(STATS_ENDPOINT));
 
-        final String[] goNames = statsSetupHelper.expectedNames(expectedDistinctValueCount, GO_TERM_NAME);
-        final String[] taxonNames = statsSetupHelper.expectedNames(expectedDistinctValueCount, TAXON_TERM_NAME);
-        final String[] ecoNames = statsSetupHelper.expectedNames(expectedDistinctValueCount, ECO_TERM_NAME);
+        final String[] goNames = expectedNames(expectedDistinctValueCount, GO_TERM_NAME);
+        final String[] taxonNames = expectedNames(expectedDistinctValueCount, TAXON_TERM_NAME);
+        final String[] ecoNames = expectedNames(expectedDistinctValueCount, ECO_TERM_NAME);
 
         response.andDo(print())
                 .andExpect(namesInTypeWithinGroup(ANNOTATION_GROUP, GO_ID_STATS_FIELD, goNames))
@@ -467,5 +464,12 @@ public class AnnotationControllerStatisticsIT {
 
     private String createId(int idNum) {
         return String.format("A0A%03d", idNum);
+    }
+
+    private String[] expectedNames(int expectedSize, String source) {
+        String[] names = new String[expectedSize];
+        IntStream.range(0, names.length)
+                .forEach(i -> names[i] = source);
+        return names;
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
@@ -30,10 +30,7 @@ import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.WebApplicationContext;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Arrays.asList;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -65,7 +62,6 @@ public class AnnotationControllerStatisticsIT {
 
     private static final String RESOURCE_URL = "/annotation";
     private static final String STATS_ENDPOINT = RESOURCE_URL + "/stats";
-    private static final String BASE_URL = "https://localhost";
     private static final String GO_TERM_NAME = "catalytic activity";
     private static final String ECO_TERM_NAME = "match to sequence model evidence used in automatic assertion";
     private static final String TAXON_TERM_NAME = "taxon name: " + 12345;
@@ -177,7 +173,7 @@ public class AnnotationControllerStatisticsIT {
 
         statsSetupHelper.expectGoTermHasNameViaRest(GO_ID, GO_TERM_NAME);
         statsSetupHelper.expectTaxonIdHasNameViaRest(String.valueOf(TAXON_ID), TAXON_NAME);
-        statsSetupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME);
+        statsSetupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME, expectedDistinctValueCount);
 
         assertStatsResponseIncludingNames(expectedDistinctValueCount);
     }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
@@ -113,7 +113,7 @@ public class AnnotationControllerStatisticsIT {
         mockRestServiceServer = MockRestServiceServer.createServer((RestTemplate) restOperations);
         savedDocs = createGenericDocs(NUMBER_OF_GENERIC_DOCS);
         repository.save(savedDocs);
-        statsSetupHelper = new StatsSetupHelper();
+        statsSetupHelper = new StatsSetupHelper(mockRestServiceServer);
     }
 
     @Test
@@ -175,9 +175,9 @@ public class AnnotationControllerStatisticsIT {
         cacheManager.clearAll();
         final int expectedDistinctValueCount = 1;
 
-        statsSetupHelper.expectGoTermHasNameViaRest(mockRestServiceServer, GO_ID, GO_TERM_NAME);
-        statsSetupHelper.expectTaxonIdHasNameViaRest(mockRestServiceServer, String.valueOf(TAXON_ID), TAXON_NAME);
-        statsSetupHelper.expectEcoCodeHasNameViaRest(mockRestServiceServer, ECO_ID, ECO_TERM_NAME);
+        statsSetupHelper.expectGoTermHasNameViaRest(GO_ID, GO_TERM_NAME);
+        statsSetupHelper.expectTaxonIdHasNameViaRest(String.valueOf(TAXON_ID), TAXON_NAME);
+        statsSetupHelper.expectEcoCodeHasNameViaRest(ECO_ID, ECO_TERM_NAME);
 
         assertStatsResponseIncludingNames(expectedDistinctValueCount);
     }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
@@ -94,6 +94,7 @@ public class AnnotationControllerStatisticsIT {
     private static final String GO_ASPECT_STATS_FIELD = "aspect";
     private static final String EXACT_USAGE = "exact";
     private static final String DISTINCT_VALUE_COUNT = "distinctValueCount";
+    private static final String TAXON_NAME = "taxon name: " + TAXON_ID;
 
     private MockMvc mockMvc;
     @Autowired
@@ -507,7 +508,7 @@ public class AnnotationControllerStatisticsIT {
 
     private void expectTaxonIdHasGivenTaxonNameViaRest() {
         BasicTaxonomyNode expectedResponse = new BasicTaxonomyNode();
-        expectedResponse.setScientificName(taxonName());
+        expectedResponse.setScientificName(TAXON_NAME);
         String responseAsString = getResponseAsString(expectedResponse);
 
         expectRestCallSuccess(
@@ -569,10 +570,6 @@ public class AnnotationControllerStatisticsIT {
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("Problem constructing mocked GO term REST response:", e);
         }
-    }
-
-    private String taxonName() {
-        return "taxon name: " + TAXON_ID;
     }
 
     private String[] expectedNames(int expectedSize, String source) {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsResponseVerifier.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsResponseVerifier.java
@@ -15,6 +15,7 @@ final class StatsResponseVerifier {
     private static final String GROUP_NAME_TAG = "groupName";
     private static final String TYPE_NAME_TAG = "type";
     private static final String KEY_NAME_TAG = "key";
+    private static final String NAME_NAME_TAG = "name";
     private static final String TOTAL_GROUP_HITS_TAG = "totalHits";
 
     private StatsResponseVerifier() {}
@@ -58,14 +59,30 @@ final class StatsResponseVerifier {
      * @return a {@link ResultMatcher} that checks for the given inputs
      */
     static ResultMatcher keysInTypeWithinGroup(String group, String type, String[] keys) {
+        return targetInTypeWithinGroup(group, type, keys, KEY_NAME_TAG);
+    }
+
+    /**
+     * Checks that all of the names defined in the {@param names} array are present in the {@param
+     * type} within the given {@param group}.
+     *
+     * @param group the stats group to check in
+     * @param type the stats type defined within in the {@param group}
+     * @param names the names to check for
+     * @return a {@link ResultMatcher} that checks for the given inputs
+     */
+    static ResultMatcher namesInTypeWithinGroup(String group, String type, String[] names) {
+        return targetInTypeWithinGroup(group, type, names, NAME_NAME_TAG);
+    }
+
+    private static ResultMatcher targetInTypeWithinGroup(String group, String type, String[] expected, String target) {
         String valuesInTypeForGroup = "%s[?(@.%s=='%s')]..[?(@.%s=='%s')]..%s";
         return jsonPath(
                 format(valuesInTypeForGroup,
                         ResponseVerifier.RESULTS,
                         GROUP_NAME_TAG, group,
                         TYPE_NAME_TAG, type,
-                        KEY_NAME_TAG),
-                containsInAnyOrder(keys)
-        );
+                        target),
+                containsInAnyOrder(expected));
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
@@ -37,31 +37,28 @@ public class StatsSetupHelper {
         this.mockRestServiceServer = mockRestServiceServer;
     }
 
-    void expectRestCallSuccess(String url, String response) {
+    void expectRestCall(String url, ResponseCreator response) {
         mockRestServiceServer.expect(
                 requestTo(BASE_URL + url))
                 .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+                .andRespond(response);
     }
 
-    void expectGORestCallResponse(String id, ResponseCreator
-            response) {
+    void expectGORestCallResponse(String id, ResponseCreator response) {
         mockRestServiceServer.expect(
                 requestTo(BASE_URL + this.buildResource(GO_TERM_RESOURCE_FORMAT, id)))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(response);
     }
 
-    void expectTaxonomyRestCallResponse(String id, ResponseCreator
-            response) {
+    void expectTaxonomyRestCallResponse(String id, ResponseCreator response) {
         mockRestServiceServer.expect(
                 requestTo(BASE_URL + this.buildResource(TAXONOMY_ID_NODE_RESOURCE_FORMAT, id)))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(response);
     }
 
-    void expectEcoRestCallResponse(String id, ResponseCreator
-            response) {
+    void expectEcoRestCallResponse(String id, ResponseCreator response) {
         mockRestServiceServer.expect(
                 requestTo(BASE_URL + this.buildResource(ECO_TERM_RESOURCE_FORMAT, id)))
                 .andExpect(method(HttpMethod.GET))
@@ -94,8 +91,9 @@ public class StatsSetupHelper {
 
     void expectTaxonIdHasNameViaRest(String id, String name) {
         String responseAsString = constructTaxonomyTermsResponseObject(name);
-        this.expectRestCallSuccess(
-                this.buildResource(TAXONOMY_ID_NODE_RESOURCE_FORMAT, id), responseAsString);
+        this.expectRestCall(
+                this.buildResource(TAXONOMY_ID_NODE_RESOURCE_FORMAT, id), withSuccess(responseAsString, MediaType
+                        .APPLICATION_JSON));
     }
 
     String[] expectedNames(int expectedSize, String source) {
@@ -106,9 +104,10 @@ public class StatsSetupHelper {
     }
 
     private void expectIdHasGivenResultViaOntologyRest(String resourceFormat, String id, String result) {
-        this.expectRestCallSuccess(
+        this.expectRestCall(
                 this.buildResource(resourceFormat, id),
-                this.constructOntologyTermsResponseObject(id, result));
+                withSuccess(this.constructOntologyTermsResponseObject(id, result), MediaType
+                        .APPLICATION_JSON));
     }
 
     private String constructOntologyTermsResponseObject(String id, String termName) {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
@@ -1,6 +1,5 @@
 package uk.ac.ebi.quickgo.annotation.controller;
 
-import uk.ac.ebi.quickgo.annotation.IdGeneratorUtil;
 import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.BasicOntology;
 import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.BasicTaxonomyNode;
 
@@ -16,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.client.ResponseCreator;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
@@ -53,18 +53,21 @@ public class StatsSetupHelper {
                 .forEach(i -> expectResultViaOntologyRest(ECO_TERM_RESOURCE_FORMAT, ecoId, ecoTermName));
     }
 
-    void expectFailureToGetTaxonomyNameViaRest(String id) {
-        expectRestCall(buildResource(TAXONOMY_RESOURCE_FORMAT, id), withStatus(HttpStatus.NOT_FOUND));
-    }
-
-    void expectFailureToGetEcoNameViaRest(String id) {
-        expectRestCall(buildResource(ECO_TERM_RESOURCE_FORMAT, id), withStatus(HttpStatus.NOT_FOUND));
-    }
-
     void expectFailureToGetNameForGoTermViaRest(int number, Function<Integer, String> toId) {
         IntStream.range(0, number)
                 .mapToObj(i -> buildResource(GO_TERM_RESOURCE_FORMAT, toId.apply(i)))
-                .forEach(r -> expectRestCall(r, withStatus(HttpStatus.NOT_FOUND)));
+                .forEach(r -> expectRestCall(r, withStatus(NOT_FOUND)));
+    }
+
+    void expectFailureToGetTaxonomyNameViaRest(String id, int number) {
+        IntStream.range(0, number)
+                .forEach(i -> expectRestCall(buildResource(TAXONOMY_RESOURCE_FORMAT, id), withStatus(NOT_FOUND)));
+    }
+
+    void expectFailureToGetEcoNameViaRest(String id, int number) {
+        IntStream.range(0, number)
+                .forEach(i ->
+                        expectRestCall(buildResource(ECO_TERM_RESOURCE_FORMAT, id), withStatus(NOT_FOUND)));
     }
 
     void expectTaxonIdHasNameViaRest(String id, String name) {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -42,9 +43,9 @@ public class StatsSetupHelper {
         this.expectResultViaOntologyRest(GO_TERM_RESOURCE_FORMAT, id, name);
     }
 
-    void expectGoTermHasNameViaRest(int number) {
+    void expectGoTermHasNameViaRest(int number, Function<Integer, String> toId, Function<Integer, String> toName) {
         IntStream.range(0, number)
-                .forEach(i -> expectGoTermHasNameViaRest(goId(i), goName(i)));
+                .forEach(i -> expectGoTermHasNameViaRest(toId.apply(i), toName.apply(i)));
     }
 
     void expectEcoCodeHasNameViaRest(String ecoId, String ecoTermName, int number) {
@@ -60,18 +61,10 @@ public class StatsSetupHelper {
         expectRestCall(buildResource(ECO_TERM_RESOURCE_FORMAT, id), withStatus(HttpStatus.NOT_FOUND));
     }
 
-    void expectFailureToGetNameForGoTermViaRest(int number) {
+    void expectFailureToGetNameForGoTermViaRest(int number, Function<Integer, String> toId) {
         IntStream.range(0, number)
-                .mapToObj(i -> buildResource(GO_TERM_RESOURCE_FORMAT, goId(i)))
+                .mapToObj(i -> buildResource(GO_TERM_RESOURCE_FORMAT, toId.apply(i)))
                 .forEach(r -> expectRestCall(r, withStatus(HttpStatus.NOT_FOUND)));
-    }
-
-    private String goId(int id) {
-        return IdGeneratorUtil.createGoId(id);
-    }
-
-    String goName(int id) {
-        return IdGeneratorUtil.createGoId(id) + " name";
     }
 
     void expectTaxonIdHasNameViaRest(String id, String name) {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
@@ -10,8 +10,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.client.ResponseCreator;
 
@@ -49,9 +47,9 @@ public class StatsSetupHelper {
                 .forEach(i -> expectGoTermHasNameViaRest(toId.apply(i), toName.apply(i)));
     }
 
-    void expectFailureToGetEcoNameViaRest(String id, int number) {
+    void expectEcoCodeHasNameViaRest(String id, String name, int number) {
         IntStream.range(0, number)
-                .forEach(i -> expectRestCall(buildECOResource(id), withStatus(NOT_FOUND)));
+                .forEach(i -> expectResultViaOntologyRest(ECO_TERM_RESOURCE_FORMAT, id, name));
     }
 
     void expectFailureToGetNameForGoTermViaRest(int number, Function<Integer, String> toId) {
@@ -65,14 +63,14 @@ public class StatsSetupHelper {
                 .forEach(i -> expectRestCall(buildTaxResource(id), withStatus(NOT_FOUND)));
     }
 
-    void expectEcoCodeHasNameViaRest(String id, String name, int number) {
-        IntStream.range(0, number)
-                .forEach(i -> expectResultViaOntologyRest(ECO_TERM_RESOURCE_FORMAT, id, name));
-    }
-
     void expectTaxonIdHasNameViaRest(String id, String name) {
         String responseAsString = constructTaxonomyTermsResponseObject(name);
         expectRestCall(buildTaxResource(id), withSuccess(responseAsString, APPLICATION_JSON));
+    }
+
+    void expectFailureToGetEcoNameViaRest(String id, int number) {
+        IntStream.range(0, number)
+                .forEach(i -> expectRestCall(buildECOResource(id), withStatus(NOT_FOUND)));
     }
 
     private void expectResultViaOntologyRest(String resourceFormat, String id, String response) {

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.client.ResponseCreator;
@@ -18,7 +17,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Collections.singletonList;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /**
@@ -35,11 +33,12 @@ public class StatsSetupHelper {
     private ObjectMapper dtoMapper = new ObjectMapper();
     private MockRestServiceServer mockRestServiceServer;
 
-    //    public StatsSetupHelper(MockRestServiceServer mockRestServiceServer) {
-    //        this.mockRestServiceServer = mockRestServiceServer;
-    //    }
+    StatsSetupHelper(
+            MockRestServiceServer mockRestServiceServer) {
+        this.mockRestServiceServer = mockRestServiceServer;
+    }
 
-    public String constructOntologyTermsResponseObject(List<String> termIds, List<String> termNames) {
+    String constructOntologyTermsResponseObject(List<String> termIds, List<String> termNames) {
         checkArgument(termIds != null, "termIds cannot be null");
         checkArgument(termNames != null, "termIds cannot be null");
         checkArgument(termIds.size() == termNames.size(),
@@ -59,7 +58,7 @@ public class StatsSetupHelper {
         return getResponseAsString(response);
     }
 
-    public <T> String getResponseAsString(T response) {
+    <T> String getResponseAsString(T response) {
         try {
             return dtoMapper.writeValueAsString(response);
         } catch (JsonProcessingException e) {
@@ -67,14 +66,14 @@ public class StatsSetupHelper {
         }
     }
 
-    public void expectRestCallSuccess(MockRestServiceServer mockRestServiceServer, String url, String response) {
+    void expectRestCallSuccess(String url, String response) {
         mockRestServiceServer.expect(
                 requestTo(BASE_URL + url))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
     }
 
-    void expectGORestCallResponse(MockRestServiceServer mockRestServiceServer, String id, ResponseCreator
+    void expectGORestCallResponse(String id, ResponseCreator
             response) {
         mockRestServiceServer.expect(
                 requestTo(BASE_URL + this.buildResource(GO_TERM_RESOURCE_FORMAT, id)))
@@ -82,7 +81,7 @@ public class StatsSetupHelper {
                 .andRespond(response);
     }
 
-    void expectTaxonomyRestCallResponse(MockRestServiceServer mockRestServiceServer, String id, ResponseCreator
+    void expectTaxonomyRestCallResponse(String id, ResponseCreator
             response) {
         mockRestServiceServer.expect(
                 requestTo(BASE_URL + this.buildResource(TAXONOMY_ID_NODE_RESOURCE_FORMAT, id)))
@@ -90,7 +89,7 @@ public class StatsSetupHelper {
                 .andRespond(response);
     }
 
-    void expectEcoRestCallResponse(MockRestServiceServer mockRestServiceServer, String id, ResponseCreator
+    void expectEcoRestCallResponse(String id, ResponseCreator
             response) {
         mockRestServiceServer.expect(
                 requestTo(BASE_URL + this.buildResource(ECO_TERM_RESOURCE_FORMAT, id)))
@@ -98,14 +97,14 @@ public class StatsSetupHelper {
                 .andRespond(response);
     }
 
-    public String[] expectedNames(int expectedSize, String source) {
+    String[] expectedNames(int expectedSize, String source) {
         String[] names = new String[expectedSize];
         IntStream.range(0, names.length)
                 .forEach(i -> names[i] = source);
         return names;
     }
 
-    public String buildResource(String format, String... arguments) {
+    String buildResource(String format, String... arguments) {
         int requiredArgsCount = format.length() - format.replace("%", "").length();
         List<String> args = new ArrayList<>();
         for (int i = 0; i < requiredArgsCount; i++) {
@@ -118,27 +117,27 @@ public class StatsSetupHelper {
         return String.format(format, args.toArray());
     }
 
-    void expectGoTermHasNameViaRest(MockRestServiceServer mockRestServiceServer, String termId, String termName) {
-        this.expectIdHasGivenResultViaOntologyRest(mockRestServiceServer, GO_TERM_RESOURCE_FORMAT, termId, termName);
+    void expectGoTermHasNameViaRest(String termId, String termName) {
+        this.expectIdHasGivenResultViaOntologyRest(GO_TERM_RESOURCE_FORMAT, termId, termName);
     }
 
-    void expectEcoCodeHasNameViaRest(MockRestServiceServer mockRestServiceServer, String ecoId, String ecoTermName) {
-        this.expectIdHasGivenResultViaOntologyRest(mockRestServiceServer, ECO_TERM_RESOURCE_FORMAT, ecoId,
+    void expectEcoCodeHasNameViaRest(String ecoId, String ecoTermName) {
+        this.expectIdHasGivenResultViaOntologyRest(ECO_TERM_RESOURCE_FORMAT, ecoId,
                 ecoTermName);
     }
 
-    private void expectIdHasGivenResultViaOntologyRest(MockRestServiceServer mockRestServiceServer, String
+    private void expectIdHasGivenResultViaOntologyRest(String
             resourceFormat, String id, String result) {
-        this.expectRestCallSuccess(mockRestServiceServer,
+        this.expectRestCallSuccess(
                 this.buildResource(resourceFormat, id),
                 this.constructOntologyTermsResponseObject(singletonList(id), singletonList(result)));
     }
 
-    void expectTaxonIdHasNameViaRest(MockRestServiceServer mockRestServiceServer, String id, String name) {
+    void expectTaxonIdHasNameViaRest(String id, String name) {
         BasicTaxonomyNode expectedResponse = new BasicTaxonomyNode();
         expectedResponse.setScientificName(name);
         String responseAsString = this.getResponseAsString(expectedResponse);
-        this.expectRestCallSuccess(mockRestServiceServer,
+        this.expectRestCallSuccess(
                 this.buildResource(TAXONOMY_ID_NODE_RESOURCE_FORMAT, id), responseAsString);
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/StatsSetupHelper.java
@@ -1,0 +1,144 @@
+package uk.ac.ebi.quickgo.annotation.controller;
+
+import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.BasicOntology;
+import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.BasicTaxonomyNode;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.ResponseCreator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Collections.singletonList;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * @author Tony Wardell
+ * Date: 20/12/2017
+ * Time: 13:17
+ * Created with IntelliJ IDEA.
+ */
+public class StatsSetupHelper {
+    private static final String GO_TERM_RESOURCE_FORMAT = "/ontology/go/terms/%s";
+    private static final String ECO_TERM_RESOURCE_FORMAT = "/ontology/eco/terms/%s";
+    private static final String TAXONOMY_ID_NODE_RESOURCE_FORMAT = "/proteins/api/taxonomy/id/%s/node";
+    private static final String BASE_URL = "https://localhost";
+    private ObjectMapper dtoMapper = new ObjectMapper();
+    private MockRestServiceServer mockRestServiceServer;
+
+    //    public StatsSetupHelper(MockRestServiceServer mockRestServiceServer) {
+    //        this.mockRestServiceServer = mockRestServiceServer;
+    //    }
+
+    public String constructOntologyTermsResponseObject(List<String> termIds, List<String> termNames) {
+        checkArgument(termIds != null, "termIds cannot be null");
+        checkArgument(termNames != null, "termIds cannot be null");
+        checkArgument(termIds.size() == termNames.size(),
+                "termIds and termNames lists must be the same size");
+
+        BasicOntology response = new BasicOntology();
+        List<BasicOntology.Result> results = new ArrayList<>();
+
+        for (int i = 0; i < termIds.size(); i++) {
+            BasicOntology.Result result = new BasicOntology.Result();
+            result.setId(termIds.get(i));
+            result.setName(termNames.get(i));
+            results.add(result);
+        }
+
+        response.setResults(results);
+        return getResponseAsString(response);
+    }
+
+    public <T> String getResponseAsString(T response) {
+        try {
+            return dtoMapper.writeValueAsString(response);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Problem constructing mocked GO term REST response:", e);
+        }
+    }
+
+    public void expectRestCallSuccess(MockRestServiceServer mockRestServiceServer, String url, String response) {
+        mockRestServiceServer.expect(
+                requestTo(BASE_URL + url))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+    }
+
+    void expectGORestCallResponse(MockRestServiceServer mockRestServiceServer, String id, ResponseCreator
+            response) {
+        mockRestServiceServer.expect(
+                requestTo(BASE_URL + this.buildResource(GO_TERM_RESOURCE_FORMAT, id)))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(response);
+    }
+
+    void expectTaxonomyRestCallResponse(MockRestServiceServer mockRestServiceServer, String id, ResponseCreator
+            response) {
+        mockRestServiceServer.expect(
+                requestTo(BASE_URL + this.buildResource(TAXONOMY_ID_NODE_RESOURCE_FORMAT, id)))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(response);
+    }
+
+    void expectEcoRestCallResponse(MockRestServiceServer mockRestServiceServer, String id, ResponseCreator
+            response) {
+        mockRestServiceServer.expect(
+                requestTo(BASE_URL + this.buildResource(ECO_TERM_RESOURCE_FORMAT, id)))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(response);
+    }
+
+    public String[] expectedNames(int expectedSize, String source) {
+        String[] names = new String[expectedSize];
+        IntStream.range(0, names.length)
+                .forEach(i -> names[i] = source);
+        return names;
+    }
+
+    public String buildResource(String format, String... arguments) {
+        int requiredArgsCount = format.length() - format.replace("%", "").length();
+        List<String> args = new ArrayList<>();
+        for (int i = 0; i < requiredArgsCount; i++) {
+            if (i < arguments.length) {
+                args.add(arguments[i]);
+            } else {
+                args.add("");
+            }
+        }
+        return String.format(format, args.toArray());
+    }
+
+    void expectGoTermHasNameViaRest(MockRestServiceServer mockRestServiceServer, String termId, String termName) {
+        this.expectIdHasGivenResultViaOntologyRest(mockRestServiceServer, GO_TERM_RESOURCE_FORMAT, termId, termName);
+    }
+
+    void expectEcoCodeHasNameViaRest(MockRestServiceServer mockRestServiceServer, String ecoId, String ecoTermName) {
+        this.expectIdHasGivenResultViaOntologyRest(mockRestServiceServer, ECO_TERM_RESOURCE_FORMAT, ecoId,
+                ecoTermName);
+    }
+
+    private void expectIdHasGivenResultViaOntologyRest(MockRestServiceServer mockRestServiceServer, String
+            resourceFormat, String id, String result) {
+        this.expectRestCallSuccess(mockRestServiceServer,
+                this.buildResource(resourceFormat, id),
+                this.constructOntologyTermsResponseObject(singletonList(id), singletonList(result)));
+    }
+
+    void expectTaxonIdHasNameViaRest(MockRestServiceServer mockRestServiceServer, String id, String name) {
+        BasicTaxonomyNode expectedResponse = new BasicTaxonomyNode();
+        expectedResponse.setScientificName(name);
+        String responseAsString = this.getResponseAsString(expectedResponse);
+        this.expectRestCallSuccess(mockRestServiceServer,
+                this.buildResource(TAXONOMY_ID_NODE_RESOURCE_FORMAT, id), responseAsString);
+    }
+}

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/transformer/EvidenceNameInjectorTestHelper.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/transformer/EvidenceNameInjectorTestHelper.java
@@ -1,0 +1,48 @@
+package uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer;
+
+import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.BasicOntology;
+import uk.ac.ebi.quickgo.rest.search.request.FilterRequest;
+import uk.ac.ebi.quickgo.rest.search.results.transformer.AbstractValueInjector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
+
+/**
+ * @author Tony Wardell
+ * Date: 24/10/2017
+ * Time: 11:37
+ * Created with IntelliJ IDEA.
+ */
+public class EvidenceNameInjectorTestHelper {
+    public static String TEST_EVIDENCE_ID = "evidence code in test";
+    public static final BasicOntology basicOntology = createBasicOntology();
+
+    private static BasicOntology createBasicOntology() {
+        BasicOntology ontology = new BasicOntology();
+        List<BasicOntology.Result> results = new ArrayList<>();
+        BasicOntology.Result result = new BasicOntology.Result();
+        result.setId("ID:1");
+        result.setName("Name:1");
+        results.add(result);
+        ontology.setResults(results);
+        return ontology;
+    }
+
+    public static void buildFilterRequestSuccessfully(FilterRequest filterRequest, AbstractValueInjector nameInjector) {
+        assertThat(filterRequest.getProperties(), hasEntry(nameInjector.getId(), emptyList()));
+        assertThat(filterRequest.getProperties(), hasEntry("evidenceCode", singletonList(TEST_EVIDENCE_ID)));
+    }
+
+    public static void injectValueSuccessfully(String goName) {
+        assertThat(goName, is(not(nullValue())));
+        assertThat(goName, is(basicOntology.getResults().get(0).getName()));
+    }
+}

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/transformer/completablevalue/EvidenceNameInjectorTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/transformer/completablevalue/EvidenceNameInjectorTest.java
@@ -1,0 +1,54 @@
+package uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.completablevalue;
+
+import uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.BasicOntology;
+import uk.ac.ebi.quickgo.rest.model.CompletableValue;
+import uk.ac.ebi.quickgo.rest.search.request.FilterRequest;
+import uk.ac.ebi.quickgo.rest.search.request.converter.ConvertedFilter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.transformer.EvidenceNameInjectorTestHelper.*;
+
+/**
+ * Created 11/04/17
+ * @author Tony Wardell
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EvidenceNameInjectorTest {
+    private EvidenceNameInjector nameInjector;
+    private CompletableValue completableValue;
+
+    @Before
+    public void setUp() {
+        nameInjector = new EvidenceNameInjector();
+        completableValue = new CompletableValue(TEST_EVIDENCE_ID);
+    }
+
+    @Test
+    public void injectorIdIsGoName() {
+        assertThat(nameInjector.getId(), is("evidenceName"));
+    }
+
+    @Test
+    public void responseValueIsInjectedToAnnotation() {
+        ConvertedFilter<BasicOntology> stubConvertedFilter = new ConvertedFilter<>(basicOntology);
+        assertThat(completableValue.value, is(nullValue()));
+
+        nameInjector.injectValueFromResponse(stubConvertedFilter, completableValue);
+
+        injectValueSuccessfully(completableValue.value);
+    }
+
+    @Test
+    public void correctFilterRequestIsBuilt() {
+        FilterRequest filterRequest = nameInjector.buildFilterRequest(completableValue);
+
+        buildFilterRequestSuccessfully(filterRequest, nameInjector);
+    }
+}

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/transformer/completablevalue/EvidenceNameInjectorTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/comm/rest/ontology/transformer/completablevalue/EvidenceNameInjectorTest.java
@@ -31,7 +31,7 @@ public class EvidenceNameInjectorTest {
     }
 
     @Test
-    public void injectorIdIsGoName() {
+    public void injectorIdIsEvidenceName() {
         assertThat(nameInjector.getId(), is("evidenceName"));
     }
 

--- a/annotation-rest/src/test/resources/application.yml
+++ b/annotation-rest/src/test/resources/application.yml
@@ -61,6 +61,15 @@ search:
           responseClass: "uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.BasicTaxonomyNode",
           responseConverter: "uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.converter.BasicTaxonomyNodeIdentityFilterConverter"
         }
+      - signature: evidenceCode,evidenceName
+        execution: REST_COMM
+        properties: {
+          ip: "https://localhost",
+          resourceFormat: "/ontology/eco/terms/{evidenceCode}",
+          responseClass: "uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.model.BasicOntology",
+          responseConverter: "uk.ac.ebi.quickgo.annotation.service.comm.rest.ontology.converter.BasicOntologyIdentityFilterConverter",
+          timeout: 15000
+        }
   wildcard:
     fields: extension_search
 model:


### PR DESCRIPTION
The statistics json will now contain the term names (go and eco) and taxon names.