### PR TITLE
Goa 3124 distinct value count does not match result size

### DIFF
--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/controller/AnnotationControllerStatisticsIT.java
@@ -79,7 +79,7 @@ public class AnnotationControllerStatisticsIT {
     private static final String TAXON_ID_STATS_FIELD = "taxonId";
     private static final String GO_ASPECT_STATS_FIELD = "aspect";
     private static final String EXACT_USAGE = "exact";
-    private static final String DISTINCT_VALUE_COUNT = "distinctValueCount";
+    private static final String APPROXIMATE_COUNT = "approximateCount";
     private static final String TAXON_NAME = "taxon name: " + TAXON_ID;
     private static final String GENE_PRODUCT_ID_STATS_FIELD = "geneProductId";
     public static final int EXPECTED_NUMBER_OF_TYPES = 6;
@@ -465,7 +465,7 @@ public class AnnotationControllerStatisticsIT {
                 .andExpect(totalHitsInGroup(GENE_PRODUCT_GROUP, totalHits))
                 .andExpect(numberOfTypes(ANNOTATION_GROUP, expectedNumberOfTypes))
                 .andExpect(numberOfTypes(GENE_PRODUCT_GROUP, expectedNumberOfTypes))
-                .andExpect(numericValueForGroup(ANNOTATION_GROUP, statsType, DISTINCT_VALUE_COUNT,
+                .andExpect(numericValueForGroup(ANNOTATION_GROUP, statsType, APPROXIMATE_COUNT,
                         expectedDistinctValueCount))
                 .andExpect(keysInTypeWithinGroup(ANNOTATION_GROUP, statsType, asArray(statsValues)))
                 .andExpect(keysInTypeWithinGroup(GENE_PRODUCT_GROUP, statsType, asArray(statsValues)));

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/model/StatisticsByTypeTest.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.quickgo.annotation.model;
 
+import java.util.stream.IntStream;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -16,12 +17,10 @@ public class StatisticsByTypeTest {
 
     @Test
     public void nullTypeThrowsException() {
-        String type = null;
-
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Statistics type cannot be null or empty");
 
-        new StatisticsByType(type, 0);
+        new StatisticsByType(null, 0);
     }
 
     @Test
@@ -35,7 +34,7 @@ public class StatisticsByTypeTest {
     }
 
     @Test
-    public void negativeDistinctValueCountThrowsException() {
+    public void negativeApproximateCountThrowsException() {
         String type = "type";
 
         thrown.expect(IllegalArgumentException.class);
@@ -47,52 +46,70 @@ public class StatisticsByTypeTest {
     @Test
     public void nullStatisticsValueThrowsException() {
         String type = "type";
-        StatisticsValue value = null;
-
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Stats value cannot be null");
 
         StatisticsByType statsType = new StatisticsByType(type, 0);
-        statsType.addValue(value);
+        statsType.addValue(null);
     }
 
     @Test
-    public void zeroDistinctValueCountIsOK() {
+    public void zeroApproximateCountIsOK() {
         String type = "type";
         StatisticsByType statsType = new StatisticsByType(type, 0);
 
-        assertThat(statsType.getDistinctValueCount(), is(0));
+        assertThat(statsType.getApproximateCount(), is(0));
     }
 
     @Test
-    public void distinctValueCountBelow10001IsUnchanged() {
+    public void approximateCountBelow10001IsUnchanged() {
         String type = "type";
         StatisticsByType statsType = new StatisticsByType(type, 10000);
 
-        assertThat(statsType.getDistinctValueCount(), is(10000));
+        assertThat(statsType.getApproximateCount(), is(10000));
     }
 
     @Test
-    public void distinctValueCountRoundedDownIfValueGreaterThan10KAndEndsWith101To499() {
+    public void approximateCountRoundedDownIfValueGreaterThan10KAndEndsWith101To499() {
         String type = "type";
         StatisticsByType statsType = new StatisticsByType(type, 10001);
 
-        assertThat(statsType.getDistinctValueCount(), is(10000));
+        assertThat(statsType.getApproximateCount(), is(10000));
     }
 
     @Test
-    public void distinctValueCountRoundedDownIfEndsWith499OrLess() {
+    public void approximateCountRoundedDownIfEndsWith499OrLess() {
         String type = "type";
         StatisticsByType statsType = new StatisticsByType(type, 10499);
 
-        assertThat(statsType.getDistinctValueCount(), is(10000));
+        assertThat(statsType.getApproximateCount(), is(10000));
     }
 
     @Test
-    public void distinctValueCountRoundedUpIfEndsWith500OrGreater() {
+    public void approximateCountRoundedUpIfEndsWith500OrGreater() {
         String type = "type";
         StatisticsByType statsType = new StatisticsByType(type, 10500);
 
-        assertThat(statsType.getDistinctValueCount(), is(11000));
+        assertThat(statsType.getApproximateCount(), is(11000));
+    }
+
+    @Test
+    public void returnRealStatsSizeIfApproximateCountIsFewer() {
+        StatisticsByType statsType = new StatisticsByType("goId", 20);
+
+        IntStream.rangeClosed(1, 25)
+                .forEach(v -> statsType.addValue(new StatisticsValue(Integer.toString(v), v, v)));
+
+        assertThat(statsType.getApproximateCount(), is(25));
+    }
+
+    @Test
+    public void returnApproximateCountIfRealStatsSizeIsFewer() {
+        StatisticsByType statsType = new StatisticsByType("goId", 25);
+
+        IntStream.rangeClosed(1, 20)
+                .forEach(v -> statsType.addValue(new StatisticsValue(Integer.toString(v), v, v)));
+
+        assertThat(statsType.getApproximateCount(), is(25));
     }
 }

--- a/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/statistics/SlimmedStatsInjectorTest.java
+++ b/annotation-rest/src/test/java/uk/ac/ebi/quickgo/annotation/service/statistics/SlimmedStatsInjectorTest.java
@@ -160,7 +160,7 @@ public class SlimmedStatsInjectorTest {
         assertThat(slimmingGroupTypes, hasSize(1));
         StatisticsByType slimmedGoStatsType = slimmingGroupTypes.get(0);
         assertThat(slimmedGoStatsType.getType(), is(ANNOTATIONS_FOR_GO_SLIMS_NAME));
-        assertThat(slimmedGoStatsType.getDistinctValueCount(), is(slimmedGoStatsType.getValues().size()));
+        assertThat(slimmedGoStatsType.getApproximateCount(), is(slimmedGoStatsType.getValues().size()));
         return slimmedGoStatsType.getValues();
     }
 

--- a/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponse.java
+++ b/rest-common/src/main/java/uk/ac/ebi/quickgo/rest/search/results/AggregateResponse.java
@@ -55,7 +55,8 @@ import static java.util.Collections.unmodifiableSet;
  *                - aggregationResults: [5] - where 5 represents the sum of the quantities for order_item_2
  *            ...
  *        ]
- *       - distinctValueCount: the total number of order items (the results for the query may show only order items
+ *       - approximateCount: estimated total number of order items (the results for the query may show only order
+ *       items
  *       only over a certain value, or goods type.
  * </pre>
  * <p/>


### PR DESCRIPTION
Use the statistics bucket size rather than value count if bucket size is greater.
Rename distinctValueCount to approximateCount to reflect the fact its estimated.