### PR TITLE
Goa 3112 specify ancestor chart options

### DIFF
--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/controller/OBOController.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/controller/OBOController.java
@@ -617,7 +617,7 @@ public abstract class OBOController<T extends OBOTerm> {
      * @return GraphPresentation instance
      */
     private GraphPresentation buildGraphPresentation(GraphRequest request) {
-        GraphPresentation.Builder presentationBuilder = graphImageService.graphPresentationBuilder();
+        GraphPresentation.Builder presentationBuilder = new GraphPresentation.Builder();
         request.showKey().map(presentationBuilder::showKey);
         request.showIds().map(presentationBuilder::showIDs);
         request.getTermBoxWidth().map(presentationBuilder::termBoxWidth);

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/controller/OBOController.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/controller/OBOController.java
@@ -413,7 +413,7 @@ public abstract class OBOController<T extends OBOTerm> {
             bindingResult) {
         checkBindingErrors(bindingResult);
         final GraphPresentation graphPresentation = buildGraphPresentation(request);
-        final boolean base64 = request.isBase64().isPresent() ? request.isBase64().get() : false;
+        Boolean base64 = request.isBase64().map(b -> b.booleanValue()).orElse(Boolean.FALSE);
 
         try {
 

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/controller/OBOController.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/controller/OBOController.java
@@ -413,11 +413,10 @@ public abstract class OBOController<T extends OBOTerm> {
             bindingResult) {
         checkBindingErrors(bindingResult);
         final GraphPresentation graphPresentation = buildGraphPresentation(request);
-        Boolean base64 = request.isBase64().map(b -> b.booleanValue()).orElse(Boolean.FALSE);
 
         try {
 
-            return createChartResponseEntity(validationHelper.validateCSVIds(request.getIds()), base64,
+            return createChartResponseEntity(validationHelper.validateCSVIds(request.getIds()), request.isBase64(),
                     graphPresentation);
         } catch (IOException | RenderingGraphException e) {
             throw createChartGraphicsException(e);
@@ -618,12 +617,12 @@ public abstract class OBOController<T extends OBOTerm> {
      */
     private GraphPresentation buildGraphPresentation(GraphRequest request) {
         GraphPresentation.Builder presentationBuilder = new GraphPresentation.Builder();
-        request.showKey().map(presentationBuilder::showKey);
-        request.showIds().map(presentationBuilder::showIDs);
-        request.getTermBoxWidth().map(presentationBuilder::termBoxWidth);
-        request.getTermBoxHeight().map(presentationBuilder::termBoxHeight);
-        request.showSlimColours().map(presentationBuilder::showSlimColours);
-        request.showChildren().map(presentationBuilder::showChildren);
+        presentationBuilder.showKey(request.isShowKey());
+        presentationBuilder.showIDs(request.isShowIds());
+        presentationBuilder.termBoxWidth(request.getTermBoxWidth());
+        presentationBuilder.termBoxHeight(request.getTermBoxHeight());
+        presentationBuilder.showSlimColours(request.isShowSlimColours());
+        presentationBuilder.showChildren(request.isShowChildren());
         return presentationBuilder.build();
     }
 }

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/controller/OBOController.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/controller/OBOController.java
@@ -2,6 +2,8 @@ package uk.ac.ebi.quickgo.ontology.controller;
 
 import uk.ac.ebi.quickgo.common.SearchableField;
 import uk.ac.ebi.quickgo.graphics.model.GraphImageLayout;
+import uk.ac.ebi.quickgo.ontology.model.GraphRequest;
+import uk.ac.ebi.quickgo.graphics.ontology.GraphPresentation;
 import uk.ac.ebi.quickgo.graphics.ontology.RenderingGraphException;
 import uk.ac.ebi.quickgo.graphics.service.GraphImageService;
 import uk.ac.ebi.quickgo.ontology.OntologyRestConfig;
@@ -15,6 +17,7 @@ import uk.ac.ebi.quickgo.ontology.model.graph.AncestorGraph;
 import uk.ac.ebi.quickgo.ontology.model.graph.AncestorVertex;
 import uk.ac.ebi.quickgo.ontology.service.OntologyService;
 import uk.ac.ebi.quickgo.ontology.service.search.SearchServiceConfig;
+import uk.ac.ebi.quickgo.rest.ParameterBindingException;
 import uk.ac.ebi.quickgo.rest.ResponseExceptionHandler;
 import uk.ac.ebi.quickgo.rest.headers.HttpHeadersProvider;
 import uk.ac.ebi.quickgo.rest.search.RetrievalException;
@@ -32,19 +35,17 @@ import java.awt.image.RenderedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.*;
 import javax.imageio.ImageIO;
+import javax.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.http.HttpHeaders.CONTENT_ENCODING;
@@ -403,18 +404,21 @@ public abstract class OBOController<T extends OBOTerm> {
     /**
      * Retrieves the graphical image corresponding to ontology terms.
      *
-     * @param ids the term ids whose image is required
      * @return the image corresponding to the requested term ids
      */
     @ApiOperation(value = "Retrieves the PNG image corresponding to the specified ontology terms")
     @RequestMapping(value = TERMS_RESOURCE + "/{ids}/" + CHART_SUB_RESOURCE, method = RequestMethod.GET,
             produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.IMAGE_PNG_VALUE})
-    public ResponseEntity<InputStreamResource> getChart(
-            @ApiParam(value = "Comma-separated term IDs", required = true) @PathVariable(value = "ids") String ids,
-            @ApiParam(value = "Whether or not to encode the image as base64", defaultValue = "false")
-            @RequestParam(value = "base64", defaultValue = "false", required = false) boolean base64) {
+    public ResponseEntity<InputStreamResource> getChart(@Valid @ModelAttribute GraphRequest request, BindingResult
+            bindingResult) {
+        checkBindingErrors(bindingResult);
+        final GraphPresentation graphPresentation = buildGraphPresentation(request);
+        final boolean base64 = request.isBase64().isPresent() ? request.isBase64().get() : false;
+
         try {
-            return createChartResponseEntity(validationHelper.validateCSVIds(ids), base64);
+
+            return createChartResponseEntity(validationHelper.validateCSVIds(request.getIds()), base64,
+                    graphPresentation);
         } catch (IOException | RenderingGraphException e) {
             throw createChartGraphicsException(e);
         }
@@ -423,7 +427,6 @@ public abstract class OBOController<T extends OBOTerm> {
     /**
      * Retrieves the graphical image coordination information corresponding to ontology terms.
      *
-     * @param ids the term ids whose image is required
      * @return the coordinate information of the terms in the chart
      */
     @ApiOperation(value = "Retrieves coordinate information about terms within the PNG chart from the " +
@@ -431,11 +434,15 @@ public abstract class OBOController<T extends OBOTerm> {
     @RequestMapping(value = TERMS_RESOURCE + "/{ids}/" + CHART_COORDINATES_SUB_RESOURCE,
             method = RequestMethod.GET,
             produces = {MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<GraphImageLayout> getChartCoordinates(
-            @ApiParam(value = "Comma-separated term IDs", required = true) @PathVariable(value = "ids") String ids) {
+    public ResponseEntity<GraphImageLayout> getChartCoordinates(@Valid @ModelAttribute GraphRequest request,
+            BindingResult bindingResult) {
+        checkBindingErrors(bindingResult);
+        final GraphPresentation graphPresentation = buildGraphPresentation(request);
+
         try {
             GraphImageLayout layout = graphImageService
-                    .createChart(validationHelper.validateCSVIds(ids), ontologySpecifier.ontologyType.name())
+                    .createChart(validationHelper.validateCSVIds(request.getIds()), ontologySpecifier.ontologyType
+                            .name(), graphPresentation)
                     .getLayout();
             return ResponseEntity
                     .ok()
@@ -529,15 +536,18 @@ public abstract class OBOController<T extends OBOTerm> {
      *
      * @param ids the terms whose corresponding graphical image is required
      * @param base64 whether or not to encode the image as base64
+     * @param graphPresentation defines the look and attributes of the rendered graph
      * @return the image corresponding to the specified terms
      * @throws IOException if there is an error during creation of the image {@link InputStreamResource}
      * @throws RenderingGraphException if there was an error during the rendering of the image
      */
-    private ResponseEntity<InputStreamResource> createChartResponseEntity(List<String> ids, boolean base64)
+    private ResponseEntity<InputStreamResource> createChartResponseEntity(List<String> ids, boolean base64,
+            GraphPresentation graphPresentation)
             throws IOException, RenderingGraphException {
+
         RenderedImage renderedImage =
                 graphImageService
-                        .createChart(ids, ontologySpecifier.ontologyType.name())
+                        .createChart(ids, ontologySpecifier.ontologyType.name(), graphPresentation)
                         .getGraphImage()
                         .render();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
@@ -593,5 +603,27 @@ public abstract class OBOController<T extends OBOTerm> {
         return and(query,
                 ontologyQueryConverter.convert(
                         OntologyFields.Searchable.ONTOLOGY_TYPE + COLON + ontologySpecifier.ontologyType.name()));
+    }
+
+    private void checkBindingErrors(BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            throw new ParameterBindingException(bindingResult);
+        }
+    }
+
+    /**
+     * Map the values of the graph presentational parameters to an instance of GraphPresentation
+     * @param request holds the stylistic parameters requested by the client
+     * @return GraphPresentation instance
+     */
+    private GraphPresentation buildGraphPresentation(GraphRequest request) {
+        GraphPresentation.Builder presentationBuilder = graphImageService.graphPresentationBuilder();
+        request.showKey().map(presentationBuilder::showKey);
+        request.showIds().map(presentationBuilder::showIDs);
+        request.getTermBoxWidth().map(presentationBuilder::termBoxWidth);
+        request.getTermBoxHeight().map(presentationBuilder::termBoxHeight);
+        request.showSlimColours().map(presentationBuilder::showSlimColours);
+        request.showChildren().map(presentationBuilder::showChildren);
+        return presentationBuilder.build();
     }
 }

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/GraphRequest.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/GraphRequest.java
@@ -1,7 +1,8 @@
 package uk.ac.ebi.quickgo.ontology.model;
 
+import uk.ac.ebi.quickgo.graphics.ontology.GraphPresentation;
+
 import io.swagger.annotations.ApiModelProperty;
-import java.util.Optional;
 import javax.validation.constraints.Min;
 
 /**
@@ -16,19 +17,19 @@ public class GraphRequest {
     @ApiModelProperty(value = "Comma-separated term IDs")
     private String ids;
     @ApiModelProperty(value = "Whether or not to encode the image as base64")
-    private Optional<Boolean> base64 = Optional.empty();
+    private boolean base64 = false;
     @ApiModelProperty(value = "Whether or not to show the key for the ancestor graph")
-    private Optional<Boolean> showKey = Optional.empty();
+    private boolean showKey = GraphPresentation.defaultShowKey;
     @ApiModelProperty(value = "Whether or not to show the GO IDs for the ancestor graph")
-    private Optional<Boolean> showIds = Optional.empty();
+    private boolean showIds = GraphPresentation.defaultShowTermIds;
     @ApiModelProperty(value = "Term box width in pixels")
-    private Optional<Integer> termBoxWidth = Optional.empty();
+    private Integer termBoxWidth = GraphPresentation.defaultWidth;
     @ApiModelProperty(value = "Term box height in pixels")
-    private Optional<Integer> termBoxHeight = Optional.empty();
+    private Integer termBoxHeight = GraphPresentation.defaultHeight;
     @ApiModelProperty(value = "Whether or not to show the slim set a term appears in")
-    private Optional<Boolean> showSlimColours = Optional.empty();
+    private boolean showSlimColours = GraphPresentation.defaultShowSlimColours;
     @ApiModelProperty(value = "Whether or not to show the children of terms")
-    private Optional<Boolean> showChildren = Optional.empty();
+    private boolean showChildren = GraphPresentation.defaultShowChildren;
 
     public GraphRequest() {}
 
@@ -40,61 +41,61 @@ public class GraphRequest {
         this.ids = ids;
     }
 
-    public Optional<Boolean> isBase64() {
+    public boolean isBase64() {
         return base64;
     }
 
     public void setBase64(boolean val) {
-        this.base64 = Optional.of(val);
+        this.base64 = val;
     }
 
-    public Optional<Boolean> showKey() {
+    public boolean isShowKey() {
         return showKey;
     }
 
     public void setShowKey(boolean val) {
-        this.showKey = Optional.of(val);
+        this.showKey = val;
     }
 
-    public Optional<Boolean> showIds() {
+    public boolean isShowIds() {
         return showIds;
     }
 
     public void setShowIds(boolean val) {
-        this.showIds = Optional.of(val);
+        this.showIds = val;
     }
 
     @Min(value = 1)
-    public Optional<Integer> getTermBoxWidth() {
+    public int getTermBoxWidth() {
         return termBoxWidth;
     }
 
     public void setTermBoxWidth(int val) {
-        this.termBoxWidth = Optional.of(val);
+        this.termBoxWidth = val;
     }
 
     @Min(value = 1)
-    public Optional<Integer> getTermBoxHeight() {
+    public int getTermBoxHeight() {
         return termBoxHeight;
     }
 
     public void setTermBoxHeight(int val) {
-        this.termBoxHeight = Optional.of(val);
+        this.termBoxHeight = val;
     }
 
-    public Optional<Boolean> showSlimColours() {
+    public boolean isShowSlimColours() {
         return showSlimColours;
     }
 
     public void setShowSlimColours(boolean val) {
-        this.showSlimColours = Optional.of(val);
+        this.showSlimColours = val;
     }
 
-    public Optional<Boolean> showChildren() {
-        return this.showChildren;
+    public boolean isShowChildren() {
+        return showChildren;
     }
 
     public void setShowChildren(boolean val) {
-        this.showChildren = Optional.of(val);
+        this.showChildren = val;
     }
 }

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/GraphRequest.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/GraphRequest.java
@@ -1,0 +1,112 @@
+package uk.ac.ebi.quickgo.ontology.model;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Optional;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+
+/**
+ * The client can provide parameters to change the rendering of a terms chart. This class binds the parameters.
+ * @author Tony Wardell
+ * Date: 12/02/2018
+ * Time: 13:54
+ * Created with IntelliJ IDEA.
+ */
+public class GraphRequest {
+
+    @ApiModelProperty(value = "Comma-separated term IDs")
+    private String ids;
+    @ApiModelProperty(value = "Whether or not to encode the image as base64")
+    private Optional<Boolean> base64 = Optional.empty();
+    @ApiModelProperty(value = "Whether or not to show the key for the ancestor graph")
+    private Optional<Boolean> showKey = Optional.empty();
+    @ApiModelProperty(value = "Whether or not to show the GO IDs for the ancestor graph")
+    private Optional<Boolean> showIds = Optional.empty();
+    @ApiModelProperty(value = "Term box width in pixels")
+    private Optional<Integer> termBoxWidth = Optional.empty();
+    @ApiModelProperty(value = "Term box height in pixels")
+    private Optional<Integer> termBoxHeight = Optional.empty();
+    @ApiModelProperty(value = "Whether or not to show the slim set a term appears in")
+    private Optional<Boolean> showSlimColours = Optional.empty();
+    @ApiModelProperty(value = "Whether or not to show the children of terms")
+    private Optional<Boolean> showChildren = Optional.empty();
+
+    public GraphRequest() {}
+
+    public String getIds() {
+        return ids;
+    }
+
+    public void setIds(String ids) {
+        this.ids = ids;
+    }
+
+    @Pattern(regexp = "^true|false$", flags = Pattern.Flag.CASE_INSENSITIVE,
+            message = "Invalid base64: ${validatedValue}")
+    public Optional<Boolean> isBase64() {
+        return base64;
+    }
+
+    public void setBase64(boolean val) {
+        this.base64 = Optional.of(val);
+    }
+
+    @Pattern(regexp = "^true|false$", flags = Pattern.Flag.CASE_INSENSITIVE,
+            message = "Invalid showKey: ${validatedValue}")
+    public Optional<Boolean> showKey() {
+        return showKey;
+    }
+
+    public void setShowKey(boolean val) {
+        this.showKey = Optional.of(val);
+    }
+
+    @Pattern(regexp = "^true|false$", flags = Pattern.Flag.CASE_INSENSITIVE,
+            message = "Invalid showIds: ${validatedValue}")
+    public Optional<Boolean> showIds() {
+        return showIds;
+    }
+
+    public void setShowIds(boolean val) {
+        this.showIds = Optional.of(val);
+    }
+
+    @Min(value = 1)
+    public Optional<Integer> getTermBoxWidth() {
+        return termBoxWidth;
+    }
+
+    public void setTermBoxWidth(int val) {
+        this.termBoxWidth = Optional.of(val);
+    }
+
+    @Min(value = 1)
+    public Optional<Integer> getTermBoxHeight() {
+        return termBoxHeight;
+    }
+
+    public void setTermBoxHeight(int val) {
+        this.termBoxHeight = Optional.of(val);
+    }
+
+    @Pattern(regexp = "^true|false$", flags = Pattern.Flag.CASE_INSENSITIVE,
+            message = "Invalid showSlimColours: ${validatedValue}")
+    public Optional<Boolean> showSlimColours() {
+        return showSlimColours;
+    }
+
+    public void setShowSlimColours(boolean val) {
+        this.showSlimColours = Optional.of(val);
+    }
+
+    @Pattern(regexp = "^true|false$", flags = Pattern.Flag.CASE_INSENSITIVE,
+            message = "Invalid showChildren: ${validatedValue}")
+    public Optional<Boolean> showChildren() {
+        return this.showChildren;
+    }
+
+    public void setShowChildren(boolean val) {
+        this.showChildren = Optional.of(val);
+    }
+
+}

--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/GraphRequest.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/model/GraphRequest.java
@@ -3,7 +3,6 @@ package uk.ac.ebi.quickgo.ontology.model;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.Optional;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.Pattern;
 
 /**
  * The client can provide parameters to change the rendering of a terms chart. This class binds the parameters.
@@ -41,8 +40,6 @@ public class GraphRequest {
         this.ids = ids;
     }
 
-    @Pattern(regexp = "^true|false$", flags = Pattern.Flag.CASE_INSENSITIVE,
-            message = "Invalid base64: ${validatedValue}")
     public Optional<Boolean> isBase64() {
         return base64;
     }
@@ -51,8 +48,6 @@ public class GraphRequest {
         this.base64 = Optional.of(val);
     }
 
-    @Pattern(regexp = "^true|false$", flags = Pattern.Flag.CASE_INSENSITIVE,
-            message = "Invalid showKey: ${validatedValue}")
     public Optional<Boolean> showKey() {
         return showKey;
     }
@@ -61,8 +56,6 @@ public class GraphRequest {
         this.showKey = Optional.of(val);
     }
 
-    @Pattern(regexp = "^true|false$", flags = Pattern.Flag.CASE_INSENSITIVE,
-            message = "Invalid showIds: ${validatedValue}")
     public Optional<Boolean> showIds() {
         return showIds;
     }
@@ -89,8 +82,6 @@ public class GraphRequest {
         this.termBoxHeight = Optional.of(val);
     }
 
-    @Pattern(regexp = "^true|false$", flags = Pattern.Flag.CASE_INSENSITIVE,
-            message = "Invalid showSlimColours: ${validatedValue}")
     public Optional<Boolean> showSlimColours() {
         return showSlimColours;
     }
@@ -99,8 +90,6 @@ public class GraphRequest {
         this.showSlimColours = Optional.of(val);
     }
 
-    @Pattern(regexp = "^true|false$", flags = Pattern.Flag.CASE_INSENSITIVE,
-            message = "Invalid showChildren: ${validatedValue}")
     public Optional<Boolean> showChildren() {
         return this.showChildren;
     }
@@ -108,5 +97,4 @@ public class GraphRequest {
     public void setShowChildren(boolean val) {
         this.showChildren = Optional.of(val);
     }
-
 }

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
@@ -1173,10 +1173,8 @@ public abstract class OBOControllerIT {
         when(mockGraphImageResult.getGraphImage()).thenReturn(new GraphImage("Mocked GraphImage"));
         GraphImageLayout layout = new GraphImageLayout();
         layout.title = "layout title";
-        GraphPresentation.Builder builder = new GraphPresentation.Builder();
-        GraphPresentation graphPresentation = builder.build();
         when(mockGraphImageResult.getLayout()).thenReturn(layout);
-        when(graphImageService.createChart(anyListOf(String.class), anyString(), eq(graphPresentation)))
+        when(graphImageService.createChart(anyListOf(String.class), anyString(), any(GraphPresentation.class)))
                 .thenReturn(mockGraphImageResult);
     }
 

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/OBOControllerIT.java
@@ -43,7 +43,6 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
@@ -111,6 +110,9 @@ public abstract class OBOControllerIT {
 
     @Value("${ontology.cache.control.end.time:18}")
     private int cacheControlEndTime;
+    public static final String GRAPH_PRESENTATION_PARMS =
+            "?showKey=true&showIds=true&termBoxWidth=60&termBoxHeight=90&showSlimColours=true&showChildren" +
+                    "=true";
 
     @Before
     public void setup() {
@@ -972,6 +974,35 @@ public abstract class OBOControllerIT {
         ResultActions response = mockMvc.perform(get(urlTarget));
 
         expectInvalidPropertyError(response);
+    }
+
+    @Test
+    public void validGraphParametersCanBeSet() throws Exception {
+
+        final String urlTarget = buildTermsURLWithSubResource(validId, CHART_SUB_RESOURCE) + GRAPH_PRESENTATION_PARMS;
+        requestToChartServiceReturnsValidImage();
+
+        ResultActions response = mockMvc.perform(get(urlTarget));
+
+        response.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.IMAGE_PNG_VALUE))
+                .andExpect(header().doesNotExist(HttpHeaders.CONTENT_ENCODING));
+
+        MvcResult result = response.andReturn();
+        assertThat(result.getResponse().getContentLength(), is(greaterThan(0)));
+    }
+
+    @Test
+    public void canCallChartCoordsWithGraphPresentationParametersSpecified() throws Exception {
+        requestToChartServiceReturnsValidImage();
+
+        final String urlTarget = buildTermsURLWithSubResource(validId, CHART_COORDINATES_SUB_RESOURCE)
+                + GRAPH_PRESENTATION_PARMS;
+        ResultActions response = mockMvc.perform(get(urlTarget));
+
+        response.andExpect(status().isOk());
+
     }
 
     //-----------------------  Check Http Header for Cache-Control content ------------------------------------------

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/model/GraphRequestValidationIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/model/GraphRequestValidationIT.java
@@ -1,0 +1,86 @@
+package uk.ac.ebi.quickgo.ontology.model;
+
+import javax.validation.Validator;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Check the operation of the java.validation.constraints for the GraphRepresentation class.
+ * @author Tony Wardell
+ * Date: 19/02/2018
+ * Time: 11:10
+ * Created with IntelliJ IDEA.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = GraphRequestValidationIT.GraphRequestValidationConfig.class)
+public class GraphRequestValidationIT {
+
+    static class GraphRequestValidationConfig {
+
+        @Bean
+        Validator validator() {
+            return new LocalValidatorFactoryBean();
+        }
+    }
+
+    @Autowired
+    private Validator validator;
+
+    private GraphRequest graphRequest;
+
+    @Before
+    public void setUp() {
+        graphRequest = new GraphRequest();
+    }
+
+    @Test
+    public void termBoxHeightMinimum1() {
+        graphRequest.setTermBoxHeight(1);
+
+        assertThat(validator.validate(graphRequest), hasSize(0));
+    }
+
+    @Test
+    public void termBoxHeightCannotBeZero() {
+        graphRequest.setTermBoxHeight(0);
+
+        assertThat(validator.validate(graphRequest), hasSize(1));
+    }
+
+    @Test
+    public void termBoxHeightCannotBeLessThan1() {
+        graphRequest.setTermBoxHeight(-1);
+
+        assertThat(validator.validate(graphRequest), hasSize(1));
+    }
+
+    @Test
+    public void termBoxWidthMinimum1() {
+        graphRequest.setTermBoxWidth(1);
+
+        assertThat(validator.validate(graphRequest), hasSize(0));
+    }
+
+    @Test
+    public void termBoxWidthCannotBeZero() {
+        graphRequest.setTermBoxWidth(0);
+
+        assertThat(validator.validate(graphRequest), hasSize(1));
+    }
+
+    @Test
+    public void termBoxWidthCannotBeLessThan1() {
+        graphRequest.setTermBoxWidth(-1);
+
+        assertThat(validator.validate(graphRequest), hasSize(1));
+    }
+}

--- a/sources/src/main/java/uk/ac/ebi/quickgo/graphics/ontology/GraphImage.java
+++ b/sources/src/main/java/uk/ac/ebi/quickgo/graphics/ontology/GraphImage.java
@@ -13,39 +13,133 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class GraphImage extends RenderableImage {
+    public static final int keyMargin = 50;
+    public static final int rightMargin = 10;
+    public static final int bottomMargin = 16;
+    public static final int minWidth = 250;
     private static final Font labelFont = new Font("Arial", Font.PLAIN, 10);
     private static final Font infoFont = new Font("Arial", Font.PLAIN, 9);
     private static final Font errorFont = new Font("Arial", Font.PLAIN, 16);
+    public final String errorMessage;
+    public Collection<TermNode> terms = new ArrayList<>();
+    public Collection<RelationEdge> relations = new ArrayList<>();
+    public Collection<KeyNode> legend = new ArrayList<>();
+    public String selected;
+    private GraphPresentation style;
+    public GraphImage(String errorMessage) {
+        super(500, 100);
+        this.errorMessage = errorMessage;
+    }
+    public GraphImage(int width, int height, Collection<TermNode> terms, Collection<RelationEdge> relations,
+            GraphPresentation style, Collection<RelationType> relationTypes) {
+        super(Math.max(minWidth, width + (style.key ? keyMargin + (style.width * 2) + rightMargin : 0)),
+                height + bottomMargin);
+
+        this.errorMessage = null;
+
+        this.terms = terms;
+        this.relations = relations;
+        this.style = style;
+
+        if (style.key) {
+            Set<GenericTermSet> subsets = new HashSet<>();
+            if (style.subsetColours) {
+                for (TermNode node : terms) {
+                    GenericTerm t = node.getTerm();
+                    if (t != null) {
+                        subsets.addAll(t.subsets);
+                    }
+                }
+            }
+
+            //	        RelationType rta[] = {RelationType.ISA,  RelationType.PARTOF, /*RelationType.HASPART,*/
+            // RelationType.REGULATES, RelationType.POSITIVEREGULATES, RelationType.NEGATIVEREGULATES, RelationType
+            // .OCCURSIN, RelationType.USEDIN, RelationType.CAPABLEOF, RelationType.CAPABLEOFPARTOF};
+
+            int knHeight = style.height / 2;
+            int knY = knHeight;
+
+            int yMax = knY;
+            for (RelationType rt : relationTypes) {
+                KeyNode kn = new KeyNode(super.width - style.width - rightMargin, knY, style.width * 2, knHeight,
+                        rt);
+                legend.add(kn);
+                knY += knHeight;
+                yMax = kn.bottom();
+            }
+
+            int pos = 20;
+            for (GenericTermSet subset : subsets) {
+                TermNode bottomNode = subsetNode(subset.name, subset.name, pos);
+                bottomNode.colours = new int[]{subset.colour};
+                pos += 3;
+                yMax = bottomNode.bottom();
+            }
+
+            int bottom = yMax + bottomMargin;
+            if (this.height < bottom) {
+                this.height = bottom;
+            }
+        }
+    }
+
+    public String id() {
+        return String.valueOf(System.identityHashCode(this));
+    }
+
+    /**
+     * Return only GO/ECO terms nodes (no goslim ones)
+     * @return GO/ECO terms nodes (no goslim ones)
+     */
+    public Collection<TermNode> getOntologyTerms() {
+        Collection<TermNode> ontologyTerms = new ArrayList<>();
+        for (TermNode termNode : this.terms) {
+            if (!termNode.getId().contains("goslim")) {
+                ontologyTerms.add(termNode);
+            }
+        }
+        return ontologyTerms;
+    }
+
+    @Override
+    protected void render(Graphics2D g2) {
+        if (errorMessage != null) {
+            g2.setFont(errorFont);
+            g2.setColor(Color.BLACK);
+            g2.drawString(errorMessage, 5, 50);
+        } else {
+            for (RelationEdge relation : relations) {
+                relation.render(g2);
+            }
+            for (TermNode term : terms) {
+                term.render(g2);
+            }
+            for (KeyNode ke : legend) {
+                ke.render(g2);
+            }
+
+            g2.setFont(infoFont);
+            g2.setColor(Color.BLACK);
+            g2.drawString("QuickGO - https://www.ebi.ac.uk/QuickGO", 5, height - g2.getFontMetrics().getDescent());
+        }
+    }
+
+    private TermNode subsetNode(String name, String id, int row) {
+        TermNode node = new TermNode(name, id, style);
+        node.setWidth(node.getWidth() + 26);
+        node.setHeight(node.getHeight() / 2);
+        node.setLocation(width - node.getWidth() / 2 - rightMargin, node.getHeight() * row / 2);
+        terms.add(node);
+        return node;
+    }
 
     public static class KeyNode implements INode {
         public int xCentre;
         public int yCentre;
         public int width;
         public int height;
-
-        public static class RelationStroke extends DrawableEdge<INode> {
-            private static final Stroke relationStroke = new BasicStroke(2f);
-            private static final Shape arrow = DrawableEdge.standardArrow(8, 6, 2);
-
-            RelationType type;
-
-            public RelationStroke(int xFrom, int yFrom, int xTo, int yTo, RelationType rtype) {
-                super(null, null, Color.black, rtype.stroke == null ? relationStroke : rtype.stroke,
-                        (rtype.polarity == RelationType.Polarity.POSITIVE ||
-                                 rtype.polarity == RelationType.Polarity.BIPOLAR) ? arrow : null,
-                        (rtype.polarity == RelationType.Polarity.NEGATIVE ||
-                                 rtype.polarity == RelationType.Polarity.BIPOLAR) ? arrow : null);
-                this.type = rtype;
-                this.colour = rtype.colour;
-
-                GeneralPath shape = new GeneralPath();
-                shape.moveTo(xFrom, yFrom);
-                shape.lineTo(xTo, yTo);
-                this.setRoute(shape);
-            }
-        }
-
         RelationType relType;
+        Stroke border = new BasicStroke(1);
 
         public KeyNode(int xCentre, int yCentre, int width, int height, RelationType relType) {
             this.xCentre = xCentre;
@@ -54,8 +148,6 @@ public class GraphImage extends RenderableImage {
             this.height = height;
             this.relType = relType;
         }
-
-        Stroke border = new BasicStroke(1);
 
         public void render(Graphics2D g2) {
             int margin = height / 10;
@@ -74,17 +166,6 @@ public class GraphImage extends RenderableImage {
             Rectangle2D r = g2.getFontMetrics().getStringBounds(relType.description, g2);
             g2.drawString(relType.description, (float) (xCentre - (r.getWidth() / 2)),
                     (float) (yCentre + offsetY - (r.getHeight() / 2)));
-        }
-
-        void drawBox(Graphics2D g2, int left, int top, int width, int height, String label) {
-            g2.setColor(Color.black);
-            g2.setStroke(border);
-            g2.drawRect(left, top, width, height);
-
-            g2.setFont(labelFont);
-            Rectangle2D r = g2.getFontMetrics().getStringBounds(label, g2);
-            g2.drawString(label, (float) (left + (width / 2) - (r.getWidth() / 2)),
-                    (float) (top + (height / 2) + (r.getHeight() / 2)));
         }
 
         public int left() {
@@ -118,126 +199,38 @@ public class GraphImage extends RenderableImage {
         public int getBottom() {
             return this.bottom();
         }
-    }
 
-    public Collection<TermNode> terms = new ArrayList<>();
-    public Collection<RelationEdge> relations = new ArrayList<>();
-    public Collection<KeyNode> legend = new ArrayList<>();
+        void drawBox(Graphics2D g2, int left, int top, int width, int height, String label) {
+            g2.setColor(Color.black);
+            g2.setStroke(border);
+            g2.drawRect(left, top, width, height);
 
-    private GraphPresentation style;
+            g2.setFont(labelFont);
+            Rectangle2D r = g2.getFontMetrics().getStringBounds(label, g2);
+            g2.drawString(label, (float) (left + (width / 2) - (r.getWidth() / 2)),
+                    (float) (top + (height / 2) + (r.getHeight() / 2)));
+        }
 
-    public String selected;
-    public final String errorMessage;
+        public static class RelationStroke extends DrawableEdge<INode> {
+            private static final Stroke relationStroke = new BasicStroke(2f);
+            private static final Shape arrow = DrawableEdge.standardArrow(8, 6, 2);
 
-    public String id() {
-        return String.valueOf(System.identityHashCode(this));
-    }
+            RelationType type;
 
-    public static final int keyMargin = 50;
-    public static final int rightMargin = 10;
-    public static final int bottomMargin = 16;
-    public static final int minWidth = 250;
+            public RelationStroke(int xFrom, int yFrom, int xTo, int yTo, RelationType rtype) {
+                super(null, null, Color.black, rtype.stroke == null ? relationStroke : rtype.stroke,
+                        (rtype.polarity == RelationType.Polarity.POSITIVE ||
+                                 rtype.polarity == RelationType.Polarity.BIPOLAR) ? arrow : null,
+                        (rtype.polarity == RelationType.Polarity.NEGATIVE ||
+                                 rtype.polarity == RelationType.Polarity.BIPOLAR) ? arrow : null);
+                this.type = rtype;
+                this.colour = rtype.colour;
 
-    public GraphImage(String errorMessage) {
-        super(500, 100);
-        this.errorMessage = errorMessage;
-    }
-
-    public GraphImage(int width, int height, Collection<TermNode> terms, Collection<RelationEdge> relations,
-            GraphPresentation style, Collection<RelationType> relationTypes) {
-        super(Math.max(minWidth, width + (style.key ? keyMargin + (style.width * 2) + rightMargin : 0)),
-                height + bottomMargin);
-
-        this.errorMessage = null;
-
-        this.terms = terms;
-        this.relations = relations;
-        this.style = style;
-
-        if (style.key) {
-            Set<GenericTermSet> subsets = new HashSet<>();
-            if (style.subsetColours) {
-                for (TermNode node : terms) {
-                    GenericTerm t = node.getTerm();
-                    if (t != null) {
-                        subsets.addAll(t.subsets);
-                    }
-                }
-            }
-
-            //	        RelationType rta[] = {RelationType.ISA,  RelationType.PARTOF, /*RelationType.HASPART,*/
-            // RelationType.REGULATES, RelationType.POSITIVEREGULATES, RelationType.NEGATIVEREGULATES, RelationType
-            // .OCCURSIN, RelationType.USEDIN, RelationType.CAPABLEOF, RelationType.CAPABLEOFPARTOF};
-
-            int knHeight = style.height / 2;
-            int knY = knHeight;
-
-            int yMax = knY;
-            for (RelationType rt : relationTypes) {
-                KeyNode kn = new KeyNode(super.width - style.width - rightMargin, knY, style.width * 2, knHeight, rt);
-                legend.add(kn);
-                knY += knHeight;
-                yMax = kn.bottom();
-            }
-
-            int pos = 20;
-            for (GenericTermSet subset : subsets) {
-                TermNode bottomNode = subsetNode(subset.name, subset.name, pos);
-                bottomNode.colours = new int[]{subset.colour};
-                pos += 3;
-                yMax = bottomNode.bottom();
-            }
-
-            int bottom = yMax + bottomMargin;
-            if (this.height < bottom) {
-                this.height = bottom;
+                GeneralPath shape = new GeneralPath();
+                shape.moveTo(xFrom, yFrom);
+                shape.lineTo(xTo, yTo);
+                this.setRoute(shape);
             }
         }
-    }
-
-    private TermNode subsetNode(String name, String id, int row) {
-        TermNode node = new TermNode(name, id, style);
-        node.setWidth(node.getWidth() + 26);
-        node.setHeight(node.getHeight() / 2);
-        node.setLocation(width - node.getWidth() / 2 - rightMargin, node.getHeight() * row / 2);
-        terms.add(node);
-        return node;
-    }
-
-    @Override
-    protected void render(Graphics2D g2) {
-        if (errorMessage != null) {
-            g2.setFont(errorFont);
-            g2.setColor(Color.BLACK);
-            g2.drawString(errorMessage, 5, 50);
-        } else {
-            for (RelationEdge relation : relations) {
-                relation.render(g2);
-            }
-            for (TermNode term : terms) {
-                term.render(g2);
-            }
-            for (KeyNode ke : legend) {
-                ke.render(g2);
-            }
-
-            g2.setFont(infoFont);
-            g2.setColor(Color.BLACK);
-            g2.drawString("QuickGO - http://www.ebi.ac.uk/QuickGO", 5, height - g2.getFontMetrics().getDescent());
-        }
-    }
-
-    /**
-     * Return only GO/ECO terms nodes (no goslim ones)
-     * @return GO/ECO terms nodes (no goslim ones)
-     */
-    public Collection<TermNode> getOntologyTerms() {
-        Collection<TermNode> ontologyTerms = new ArrayList<>();
-        for (TermNode termNode : this.terms) {
-            if (!termNode.getId().contains("goslim")) {
-                ontologyTerms.add(termNode);
-            }
-        }
-        return ontologyTerms;
     }
 }

--- a/sources/src/main/java/uk/ac/ebi/quickgo/graphics/ontology/GraphPresentation.java
+++ b/sources/src/main/java/uk/ac/ebi/quickgo/graphics/ontology/GraphPresentation.java
@@ -2,35 +2,89 @@ package uk.ac.ebi.quickgo.graphics.ontology;
 
 import java.awt.*;
 
+/**
+ * Holds stylistic information for a Terms graph.
+ * Refactored by Tony Wardell
+ */
 public class GraphPresentation {
-    private static final String paramFontName = "fontName";
-    private static final String paramFontSize = "fontSize";
-    private static final String paramFill = "fill";
-    private static final String paramShowIDs = "ids";
-    private static final String paramShowKey = "key";
-    private static final String paramShowSubsets = "subsets";
-    private static final String paramShowChildren = "children";
-    private static final String paramWidth = "width";
-    private static final String paramHeight = "height";
 
-    private static final String cookieKeyPrefix = "c$";
+    public final static int fontSize = 11;
+    public final static boolean FILL = true;
+    private static final String fontName = "Arial";
+    public static final Font FONT = new Font(fontName, Font.PLAIN, fontSize);
+    static boolean defaultShowKey = true;
+    static boolean defaultShowTermIds = true;
+    static int defaultWidth = 85;
+    static int defaultHeight = 55;
+    static boolean defaultShowSlimColours = false;
+    static boolean defaultShowChildren = false;
+    //changeable
+    public final boolean termIds;
+    public final boolean key;
+    public final boolean subsetColours;
+    public final boolean showChildren;
+    public final int width;
+    public final int height;
 
-    private Font font;
+    private GraphPresentation(boolean termIds, boolean key, boolean subsetColours, boolean showChildren, int width,
+            int height) {
+        this.termIds = termIds;
+        this.key = key;
+        this.subsetColours = subsetColours;
+        this.showChildren = showChildren;
+        this.width = width;
+        this.height = height;
+    }
 
-    public String fontName = "Arial";
-    public int fontSize = 11;
-    public boolean fill = true;
-    public boolean termIds = true;
-    public boolean key = true;
-    public boolean subsetColours = true;
-    public boolean showChildren = false;
-    public int width = 85;
-    public int height = 55;
+    public static class Builder {
+        private boolean showIDs = defaultShowTermIds;
+        private boolean showKey = defaultShowKey;
+        private boolean showSlimColours = defaultShowSlimColours;
+        private boolean showChildren = defaultShowChildren;
+        private int width = defaultWidth;
+        private int height = defaultHeight;
 
-    Font getFont() {
-        if (font == null) {
-            font = new Font(fontName, Font.PLAIN, fontSize);
+        public Builder() {
         }
-        return font;
+
+        public Builder showKey(boolean val) {
+            this.showKey = val;
+            return this;
+        }
+
+        public Builder showIDs(boolean val) {
+            this.showIDs = val;
+            return this;
+        }
+
+        public Builder showSlimColours(boolean val) {
+            this.showSlimColours = val;
+            return this;
+        }
+
+        public Builder showChildren(boolean val) {
+            this.showChildren = val;
+            return this;
+        }
+
+        public Builder termBoxWidth(int val) {
+            this.width = val;
+            return this;
+        }
+
+        public Builder termBoxHeight(int val) {
+            this.height = val;
+            return this;
+        }
+
+        public GraphPresentation build() {
+            return new GraphPresentation(
+                    this.showIDs,
+                    this.showKey,
+                    this.showSlimColours,
+                    this.showChildren,
+                    this.width,
+                    this.height);
+        }
     }
 }

--- a/sources/src/main/java/uk/ac/ebi/quickgo/graphics/ontology/GraphPresentation.java
+++ b/sources/src/main/java/uk/ac/ebi/quickgo/graphics/ontology/GraphPresentation.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.quickgo.graphics.ontology;
 
 import java.awt.*;
+import java.util.Objects;
 
 /**
  * Holds stylistic information for a Terms graph.
@@ -12,12 +13,12 @@ public class GraphPresentation {
     public final static boolean FILL = true;
     private static final String fontName = "Arial";
     public static final Font FONT = new Font(fontName, Font.PLAIN, fontSize);
-    static boolean defaultShowKey = true;
-    static boolean defaultShowTermIds = true;
-    static int defaultWidth = 85;
-    static int defaultHeight = 55;
-    static boolean defaultShowSlimColours = false;
-    static boolean defaultShowChildren = false;
+    public static boolean defaultShowKey = true;
+    public static boolean defaultShowTermIds = true;
+    public static int defaultWidth = 85;
+    public static int defaultHeight = 55;
+    public static boolean defaultShowSlimColours = false;
+    public static boolean defaultShowChildren = false;
     //changeable
     public final boolean termIds;
     public final boolean key;
@@ -86,5 +87,37 @@ public class GraphPresentation {
                     this.width,
                     this.height);
         }
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GraphPresentation that = (GraphPresentation) o;
+        return termIds == that.termIds &&
+                key == that.key &&
+                subsetColours == that.subsetColours &&
+                showChildren == that.showChildren &&
+                width == that.width &&
+                height == that.height;
+    }
+
+    @Override public int hashCode() {
+
+        return Objects.hash(termIds, key, subsetColours, showChildren, width, height);
+    }
+
+    @Override public String toString() {
+        return "GraphPresentation{" +
+                "termIds=" + termIds +
+                ", key=" + key +
+                ", subsetColours=" + subsetColours +
+                ", showChildren=" + showChildren +
+                ", width=" + width +
+                ", height=" + height +
+                '}';
     }
 }

--- a/sources/src/main/java/uk/ac/ebi/quickgo/graphics/ontology/OntologyGraph.java
+++ b/sources/src/main/java/uk/ac/ebi/quickgo/graphics/ontology/OntologyGraph.java
@@ -12,18 +12,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class OntologyGraph extends GenericGraph<TermNode, RelationEdge> {
-    // map containing all terms that are part of (i.e., nodes in) the graph
-    private Map<GenericTerm, TermNode> termMap = new HashMap<>();
-    // map containing all relations that are part of (i.e., edges in) the graph 
-    private Map<TermRelation, RelationEdge> edgeMap = new HashMap<>();
+import static uk.ac.ebi.quickgo.graphics.ontology.GraphPresentation.*;
 
+public class OntologyGraph extends GenericGraph<TermNode, RelationEdge> {
+    public GraphPresentation presentation;
     EnumSet<RelationType> relationTypes;
     int ancestorLimit = 0;
     int pixelLimit = 0;
     int overflow = 0;
-
-    public GraphPresentation presentation;
+    // map containing all terms that are part of (i.e., nodes in) the graph
+    private Map<GenericTerm, TermNode> termMap = new HashMap<>();
+    // map containing all relations that are part of (i.e., edges in) the graph
+    private Map<TermRelation, RelationEdge> edgeMap = new HashMap<>();
 
     public OntologyGraph(EnumSet<RelationType> relationTypes, int ancestorLimit, int pixelLimit,
             GraphPresentation style) {
@@ -35,18 +35,6 @@ public class OntologyGraph extends GenericGraph<TermNode, RelationEdge> {
 
     public OntologyGraph(int ancestorLimit, int pixelLimit, GraphPresentation style) {
         this(null, ancestorLimit, pixelLimit, style);
-    }
-
-    void addRelation(TermRelation relation) {
-        if (!edgeMap.containsKey(relation)) {
-            TermNode pt = termMap.get(relation.parent);
-            TermNode ct = termMap.get(relation.child);
-            if (pt != null && ct != null) {
-                RelationEdge graphEdge = new RelationEdge(pt, ct, relation.typeof);
-                edgeMap.put(relation, graphEdge);
-                edges.add(graphEdge);
-            }
-        }
     }
 
     public TermNode add(GenericTerm term) {
@@ -96,7 +84,7 @@ public class OntologyGraph extends GenericGraph<TermNode, RelationEdge> {
 
     public GraphImage layout(ImageArchive imageArchive) {
         GraphImage image = layout();
-        imageArchive.store(image);
+        ImageArchive.store(image);
         return image;
     }
 
@@ -133,7 +121,7 @@ public class OntologyGraph extends GenericGraph<TermNode, RelationEdge> {
 
         for (GenericTerm term : terms.getTerms()) {
             TermNode node = graph.add(term);
-            if (node != null && style.fill) {
+            if (node != null && FILL) {
                 String colour = terms.getTermColour(term);
                 node.setFillColour(
                         new Color(colour.length() == 0 ? 0xffffcc : ColourUtils.intDecodeColour("#" + colour)));
@@ -146,5 +134,17 @@ public class OntologyGraph extends GenericGraph<TermNode, RelationEdge> {
     public static OntologyGraph makeGraph(GenericTermSet terms, int ancestorLimit, int pixelLimit,
             GraphPresentation style) {
         return makeGraph(terms, null, ancestorLimit, pixelLimit, style);
+    }
+
+    void addRelation(TermRelation relation) {
+        if (!edgeMap.containsKey(relation)) {
+            TermNode pt = termMap.get(relation.parent);
+            TermNode ct = termMap.get(relation.child);
+            if (pt != null && ct != null) {
+                RelationEdge graphEdge = new RelationEdge(pt, ct, relation.typeof);
+                edgeMap.put(relation, graphEdge);
+                edges.add(graphEdge);
+            }
+        }
     }
 }

--- a/sources/src/main/java/uk/ac/ebi/quickgo/graphics/ontology/TermNode.java
+++ b/sources/src/main/java/uk/ac/ebi/quickgo/graphics/ontology/TermNode.java
@@ -8,6 +8,8 @@ import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.List;
 
+import static uk.ac.ebi.quickgo.graphics.ontology.GraphPresentation.*;
+
 public class TermNode implements INode, IPositionableNode {
     private Font font;
 
@@ -29,11 +31,11 @@ public class TermNode implements INode, IPositionableNode {
         this.id = id;
         this.style = style;
         if (style.termIds && id.length() > 0) {
-            topLine = style.fontSize + 1;
+            topLine = fontSize + 1;
         }
         height = style.height;
         width = style.width;
-        font = style.getFont();
+        font = FONT;
     }
 
     public TermNode(GenericTerm term, GraphPresentation style) {

--- a/sources/src/main/java/uk/ac/ebi/quickgo/graphics/service/GraphImageService.java
+++ b/sources/src/main/java/uk/ac/ebi/quickgo/graphics/service/GraphImageService.java
@@ -25,10 +25,4 @@ public interface GraphImageService {
      * @throws RenderingGraphException if there was a problem rendering the graph
      */
     GraphImageResult createChart(List<String> ids, String scope, GraphPresentation graphPresentation);
-
-    /**
-     * Provide a supplier of GraphPresentation.Builder instances.
-     * @return a builder of GraphPresentation instances
-     */
-    GraphPresentation.Builder graphPresentationBuilder();
 }

--- a/sources/src/main/java/uk/ac/ebi/quickgo/graphics/service/GraphImageService.java
+++ b/sources/src/main/java/uk/ac/ebi/quickgo/graphics/service/GraphImageService.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.quickgo.graphics.service;
 
 import uk.ac.ebi.quickgo.graphics.ontology.GraphImageResult;
+import uk.ac.ebi.quickgo.graphics.ontology.GraphPresentation;
 import uk.ac.ebi.quickgo.graphics.ontology.RenderingGraphException;
 
 import java.util.List;
@@ -19,8 +20,15 @@ public interface GraphImageService {
      *
      * @param ids the term ids whose graphical representation is required
      * @param scope the scope in which the graph is being drawn. Currently this is either "ECO" or "GO".
+     * @param graphPresentation defines the look and attributes of the rendered graph
      * @return the corresponding graphical image representing the {@code ids}
      * @throws RenderingGraphException if there was a problem rendering the graph
      */
-    GraphImageResult createChart(List<String> ids, String scope);
+    GraphImageResult createChart(List<String> ids, String scope, GraphPresentation graphPresentation);
+
+    /**
+     * Provide a supplier of GraphPresentation.Builder instances.
+     * @return a builder of GraphPresentation instances
+     */
+    GraphPresentation.Builder graphPresentationBuilder();
 }

--- a/sources/src/main/java/uk/ac/ebi/quickgo/graphics/service/GraphImageServiceImpl.java
+++ b/sources/src/main/java/uk/ac/ebi/quickgo/graphics/service/GraphImageServiceImpl.java
@@ -61,11 +61,6 @@ public class GraphImageServiceImpl implements GraphImageService {
         }
     }
 
-    @Override
-    public GraphPresentation.Builder graphPresentationBuilder() {
-        return new GraphPresentation.Builder();
-    }
-
     /**
      * Creates the coordinates of the node information stored within the graph image
      * which can be used as an image-map.

--- a/sources/src/main/java/uk/ac/ebi/quickgo/graphics/service/GraphImageServiceImpl.java
+++ b/sources/src/main/java/uk/ac/ebi/quickgo/graphics/service/GraphImageServiceImpl.java
@@ -85,20 +85,24 @@ public class GraphImageServiceImpl implements GraphImageService {
         layout.imageHeight = graphImage.height;
         layout.imageWidth = graphImage.width;
 
-        graphImage.legend.stream()
-                .map(legendNode -> {
-                    GraphImageLayout.LegendPosition legendPosition = new GraphImageLayout.LegendPosition();
-                    legendPosition.bottom = legendNode.bottom();
-                    legendPosition.top = legendNode.top();
-                    legendPosition.height = legendNode.height;
-                    legendPosition.width = legendNode.width;
-                    legendPosition.left = legendNode.left();
-                    legendPosition.right = legendNode.right();
-                    legendPosition.xCentre = legendNode.xCentre;
-                    legendPosition.yCentre = legendNode.yCentre;
-                    return legendPosition;
-                })
-                .forEach(layout.legendPositions::add);
+        boolean showLegend = false;
+        if (showLegend) {
+
+            graphImage.legend.stream()
+                    .map(legendNode -> {
+                        GraphImageLayout.LegendPosition legendPosition = new GraphImageLayout.LegendPosition();
+                        legendPosition.bottom = legendNode.bottom();
+                        legendPosition.top = legendNode.top();
+                        legendPosition.height = legendNode.height;
+                        legendPosition.width = legendNode.width;
+                        legendPosition.left = legendNode.left();
+                        legendPosition.right = legendNode.right();
+                        legendPosition.xCentre = legendNode.xCentre;
+                        legendPosition.yCentre = legendNode.yCentre;
+                        return legendPosition;
+                    })
+                    .forEach(layout.legendPositions::add);
+        }
 
         layout.title = title;
 

--- a/sources/src/test/java/uk/ac/ebi/quickgo/graphics/ontology/GraphPresentationTest.java
+++ b/sources/src/test/java/uk/ac/ebi/quickgo/graphics/ontology/GraphPresentationTest.java
@@ -1,0 +1,48 @@
+package uk.ac.ebi.quickgo.graphics.ontology;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * The GraphPresentation is a data class, test it's creation, the setting of defaults.
+ * @author Tony Wardell
+ * Date: 13/02/2018
+ * Time: 15:17
+ * Created with IntelliJ IDEA.
+ */
+public class GraphPresentationTest {
+
+    @Test
+    public void usingBuilderWithNoArgumentsUsesDefaults() {
+        GraphPresentation.Builder builder = new GraphPresentation.Builder();
+        GraphPresentation graphPresentation = builder.build();
+        assertThat(GraphPresentation.defaultShowKey, is(equalTo(graphPresentation.key)));
+        assertThat(GraphPresentation.defaultShowTermIds, is(equalTo(graphPresentation.termIds)));
+        assertThat(GraphPresentation.defaultWidth, is(equalTo(graphPresentation.width)));
+        assertThat(GraphPresentation.defaultHeight, is(equalTo(graphPresentation.height)));
+        assertThat(GraphPresentation.defaultShowSlimColours, is(equalTo(graphPresentation.subsetColours)));
+        assertThat(GraphPresentation.defaultShowChildren, is(equalTo(graphPresentation.showChildren)));
+    }
+
+    @Test
+    public void suppliedArgumentsAreUsed() {
+        GraphPresentation.Builder builder = new GraphPresentation.Builder();
+        builder.showKey(!GraphPresentation.defaultShowKey)
+                .showIDs(!GraphPresentation.defaultShowTermIds)
+                .termBoxWidth(GraphPresentation.defaultWidth + 50)
+                .termBoxHeight(GraphPresentation.defaultHeight + 30)
+                .showSlimColours(!GraphPresentation.defaultShowSlimColours)
+                .showChildren(!GraphPresentation.defaultShowChildren);
+        GraphPresentation graphPresentation = builder.build();
+        assertThat(!GraphPresentation.defaultShowKey, is(equalTo(graphPresentation.key)));
+        assertThat(!GraphPresentation.defaultShowTermIds, is(equalTo(graphPresentation.termIds)));
+        assertThat(GraphPresentation.defaultWidth + 50, is(equalTo(graphPresentation.width)));
+        assertThat(GraphPresentation.defaultHeight + 30, is(equalTo(graphPresentation.height)));
+        assertThat(!GraphPresentation.defaultShowSlimColours, is(equalTo(graphPresentation.subsetColours)));
+        assertThat(!GraphPresentation.defaultShowChildren, is(equalTo(graphPresentation.showChildren)));
+    }
+
+}


### PR DESCRIPTION
~~I've tried to make the creation of the GraphPresentation as clean as possible...
I've used Option in the request handling class GraphRequest - I think its a good fit and makes the interrogation of that class super easy.~~
This wouldn't play with swagger - will Optional<Integer> was OK with a return type from GraphRequest getters, Optional<Boolean> would not work.