### PR TITLE
Remove filter during slimming that omits identity mappings.

### DIFF
--- a/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/OntologyServiceImpl.java
+++ b/ontology-rest/src/main/java/uk/ac/ebi/quickgo/ontology/service/OntologyServiceImpl.java
@@ -151,7 +151,6 @@ public class OntologyServiceImpl<T extends OBOTerm> implements OntologyService<T
                 .createSlims(OntologyType.valueOf(ontologyType), ontologyTraversal, slimsToTerms, relationTypes);
 
         return slimmer.getSlimmedTermsMap().entrySet().stream()
-                .filter(this::doesNotSlimToOnlyItself)
                 .map(Map.Entry::getKey)
                 .filter(term -> slimsFromTerms.isEmpty() || slimsFromTerms.contains(term))
                 .map(id -> new SlimTerm(id, slimmer.findSlimmedToTerms(id)))
@@ -176,17 +175,6 @@ public class OntologyServiceImpl<T extends OBOTerm> implements OntologyService<T
         Preconditions.checkArgument(ids != null, "List of IDs cannot be null");
 
         return ids.stream().map(queryStringSanitizer::sanitize).collect(Collectors.toList());
-    }
-
-    /**
-     * Determines whether a slim term maps to only itself and no other slim terms.
-     * @param slimTermMapping a slim-term and the terms to which it maps
-     * @return whether or not the slim-term maps only to itself
-     */
-    private boolean doesNotSlimToOnlyItself(Map.Entry<String, List<String>> slimTermMapping) {
-        return slimTermMapping.getValue().size() > 1 ||
-                (slimTermMapping.getValue().size() == 1 &&
-                        !slimTermMapping.getKey().equals(slimTermMapping.getValue().get(0)));
     }
 
     /**

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
@@ -16,8 +16,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -125,9 +124,22 @@ public class GOControllerIT extends OBOControllerIT {
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD1)))
-                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM1)));
+                .andExpect(jsonPath("$.numberOfHits").value(2));
+
+        expectSlimInfo(response, GO_SLIM_CHILD1, singletonList(GO_SLIM1));
+        expectIdentitySlims(response, singletonList(GO_SLIM1));
+    }
+
+    private void expectIdentitySlims(ResultActions response, List<String> slimSet) throws Exception {
+        for (String slim : slimSet) {
+            expectSlimInfo(response, slim, singletonList(slim));
+        }
+    }
+
+    private void expectSlimInfo(ResultActions response, String from, List<String> to) throws Exception {
+        response.andExpect(
+                jsonPath("$..results[?(@.slimsFromId==\"" + from + "\")].slimsToIds.*",
+                        equalTo(to)));
     }
 
     @Test
@@ -138,9 +150,10 @@ public class GOControllerIT extends OBOControllerIT {
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD1)))
-                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM1)));
+                .andExpect(jsonPath("$.numberOfHits").value(2));
+
+        expectSlimInfo(response, GO_SLIM_CHILD1, singletonList(GO_SLIM1));
+        expectIdentitySlims(response, singletonList(GO_SLIM1));
     }
 
     @Test
@@ -151,19 +164,19 @@ public class GOControllerIT extends OBOControllerIT {
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD2)))
-                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM2)));
+                .andExpect(jsonPath("$.numberOfHits").value(2));
+        expectSlimInfo(response, GO_SLIM_CHILD2, singletonList(GO_SLIM2));
+        expectIdentitySlims(response, singletonList(GO_SLIM2));
 
-        mockMvc.perform(get(getSlimURL())
+        response = mockMvc.perform(get(getSlimURL())
                 .param(SLIM_TO_IDS_PARAM, GO_SLIM3));
 
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.slimsFromId", contains(GO_SLIM_CHILD2)))
-                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM2)));
+                .andExpect(jsonPath("$.numberOfHits").value(2));
+        expectSlimInfo(response, GO_SLIM_CHILD2, singletonList(GO_SLIM3));
+        expectIdentitySlims(response, singletonList(GO_SLIM3));
     }
 
     @Test
@@ -174,9 +187,11 @@ public class GOControllerIT extends OBOControllerIT {
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.numberOfHits").value(2))
-                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD3, GO_SLIM_CHILD4)))
-                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM4, GO_SLIM4)));
+                .andExpect(jsonPath("$.numberOfHits").value(3));
+
+        expectSlimInfo(response, GO_SLIM_CHILD3, singletonList(GO_SLIM4));
+        expectSlimInfo(response, GO_SLIM_CHILD4, singletonList(GO_SLIM4));
+        expectIdentitySlims(response, singletonList(GO_SLIM4));
     }
 
     @Test
@@ -187,9 +202,11 @@ public class GOControllerIT extends OBOControllerIT {
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.numberOfHits").value(2))
-                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD5, GO_SLIM_CHILD6)))
-                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM5, GO_SLIM6, GO_SLIM5, GO_SLIM6)));
+                .andExpect(jsonPath("$.numberOfHits").value(4));
+
+        expectSlimInfo(response, GO_SLIM_CHILD5, asList(GO_SLIM5, GO_SLIM6));
+        expectSlimInfo(response, GO_SLIM_CHILD6, asList(GO_SLIM5, GO_SLIM6));
+        expectIdentitySlims(response, asList(GO_SLIM5, GO_SLIM6));
     }
 
     @Test
@@ -201,9 +218,9 @@ public class GOControllerIT extends OBOControllerIT {
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.numberOfHits").value(1))
-                .andExpect(jsonPath("$.results.*.slimsFromId", containsInAnyOrder(GO_SLIM_CHILD5)))
-                .andExpect(jsonPath("$.results.*.slimsToIds.*", contains(GO_SLIM5, GO_SLIM6)));
+                .andExpect(jsonPath("$.numberOfHits").value(1));
+
+        expectSlimInfo(response, GO_SLIM_CHILD5, asList(GO_SLIM5, GO_SLIM6));
     }
 
     @Test
@@ -284,7 +301,7 @@ public class GOControllerIT extends OBOControllerIT {
     }
 
     @Test
-    public void slimmingOverRelationshipNotInGraphReturnsEmptyResponse() throws Exception {
+    public void slimmingOverRelationshipNotInGraphReturnsIdentitySlim() throws Exception {
         String nonExistentGraphRelationship = "occurs_in";
         ResultActions response = mockMvc.perform(get(getSlimURL())
                 .param(SLIM_TO_IDS_PARAM, GO_SLIM1)
@@ -293,7 +310,9 @@ public class GOControllerIT extends OBOControllerIT {
         response.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.numberOfHits").value(0));
+                .andExpect(jsonPath("$.numberOfHits").value(1));
+
+        expectIdentitySlims(response, asList(GO_SLIM1, GO_SLIM1));
     }
 
     @Override
@@ -371,6 +390,7 @@ public class GOControllerIT extends OBOControllerIT {
         relationships.add(createSlimRelationship(GO_SLIM_CHILD5, GO_SLIM6));
         relationships.add(createSlimRelationship(GO_SLIM_CHILD6, GO_SLIM5));
         relationships.add(createSlimRelationship(GO_SLIM_CHILD6, GO_SLIM6));
+        //        relationships.add(createSlimRelationship(GO_SLIM_IDENTITY, GO_SLIM_IDENTITY));
 
         relationships.add(createSlimRelationship(GO_SLIM1, STOP_NODE));
         relationships.add(createSlimRelationship(GO_SLIM2, STOP_NODE));
@@ -379,6 +399,7 @@ public class GOControllerIT extends OBOControllerIT {
         relationships.add(createSlimRelationship(GO_SLIM5, STOP_NODE));
         relationships.add(createSlimRelationship(GO_SLIM6, STOP_NODE));
         relationships.add(createSlimRelationship(GO_SLIM7, STOP_NODE));
+        //        relationships.add(createSlimRelationship(GO_SLIM_IDENTITY, STOP_NODE));
 
         ontologyGraph.addRelationships(relationships);
     }

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
@@ -117,6 +117,20 @@ public class GOControllerIT extends OBOControllerIT {
 
     // slimming ------------------
     @Test
+    public void slimmingFromAndToTheSameTermReturnsIdentitySlim() throws Exception {
+        ResultActions response = mockMvc.perform(get(getSlimURL())
+                .param(SLIM_TO_IDS_PARAM, GO_SLIM1)
+                .param(SLIM_FROM_IDS_PARAM, GO_SLIM1));
+
+        response.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.numberOfHits").value(1));
+
+        expectIdentitySlims(response, singletonList(GO_SLIM1));
+    }
+
+    @Test
     public void oneIdHasOneSlim() throws Exception {
         ResultActions response = mockMvc.perform(get(getSlimURL())
                 .param(SLIM_TO_IDS_PARAM, GO_SLIM1));

--- a/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
+++ b/ontology-rest/src/test/java/uk/ac/ebi/quickgo/ontology/controller/GOControllerIT.java
@@ -130,18 +130,6 @@ public class GOControllerIT extends OBOControllerIT {
         expectIdentitySlims(response, singletonList(GO_SLIM1));
     }
 
-    private void expectIdentitySlims(ResultActions response, List<String> slimSet) throws Exception {
-        for (String slim : slimSet) {
-            expectSlimInfo(response, slim, singletonList(slim));
-        }
-    }
-
-    private void expectSlimInfo(ResultActions response, String from, List<String> to) throws Exception {
-        response.andExpect(
-                jsonPath("$..results[?(@.slimsFromId==\"" + from + "\")].slimsToIds.*",
-                        equalTo(to)));
-    }
-
     @Test
     public void oneIdAndOneNonExistingIdHasOneSlim() throws Exception {
         ResultActions response = mockMvc.perform(get(getSlimURL())
@@ -390,7 +378,6 @@ public class GOControllerIT extends OBOControllerIT {
         relationships.add(createSlimRelationship(GO_SLIM_CHILD5, GO_SLIM6));
         relationships.add(createSlimRelationship(GO_SLIM_CHILD6, GO_SLIM5));
         relationships.add(createSlimRelationship(GO_SLIM_CHILD6, GO_SLIM6));
-        //        relationships.add(createSlimRelationship(GO_SLIM_IDENTITY, GO_SLIM_IDENTITY));
 
         relationships.add(createSlimRelationship(GO_SLIM1, STOP_NODE));
         relationships.add(createSlimRelationship(GO_SLIM2, STOP_NODE));
@@ -399,9 +386,20 @@ public class GOControllerIT extends OBOControllerIT {
         relationships.add(createSlimRelationship(GO_SLIM5, STOP_NODE));
         relationships.add(createSlimRelationship(GO_SLIM6, STOP_NODE));
         relationships.add(createSlimRelationship(GO_SLIM7, STOP_NODE));
-        //        relationships.add(createSlimRelationship(GO_SLIM_IDENTITY, STOP_NODE));
 
         ontologyGraph.addRelationships(relationships);
+    }
+
+    private void expectIdentitySlims(ResultActions response, List<String> slimSet) throws Exception {
+        for (String slim : slimSet) {
+            expectSlimInfo(response, slim, singletonList(slim));
+        }
+    }
+
+    private void expectSlimInfo(ResultActions response, String from, List<String> to) throws Exception {
+        response.andExpect(
+                jsonPath("$..results[?(@.slimsFromId==\"" + from + "\")].slimsToIds.*",
+                        equalTo(to)));
     }
 
     private OntologyRelationship createSlimRelationship(String term, String slimmedUpTerm) {


### PR DESCRIPTION
This means terms will always map to themselves, as required by https://www.ebi.ac.uk/panda/jira/browse/GOA-3158