### PR TITLE
Goa 3201 complex portal id search

### DIFF
--- a/geneproduct-rest/src/test/java/uk/ac/ebi/quickgo/geneproduct/controller/GeneProductControllerIT.java
+++ b/geneproduct-rest/src/test/java/uk/ac/ebi/quickgo/geneproduct/controller/GeneProductControllerIT.java
@@ -7,6 +7,7 @@ import uk.ac.ebi.quickgo.geneproduct.common.GeneProductRepository;
 import uk.ac.ebi.quickgo.geneproduct.common.common.GeneProductDocMocker;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.Before;
@@ -89,6 +90,20 @@ public class GeneProductControllerIT {
     @Test
     public void canRetrieveOneGeneProductById() throws Exception {
         ResultActions response = mockMvc.perform(get(buildGeneProductURL(validId)));
+
+        response.andDo(print())
+                .andExpect(jsonPath("$.results.*.id", hasSize(1)))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void canRetrieveOneGeneProductByComplexPortalId() throws Exception {
+        geneProductRepository.deleteAll();
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        List<GeneProductDocument> basicDocs = createBasicComplexPortalDocs();
+        geneProductRepository.save(basicDocs);
+        ResultActions response = mockMvc.perform(get(buildGeneProductURL(basicDocs.get(0).id)));
 
         response.andDo(print())
                 .andExpect(jsonPath("$.results.*.id", hasSize(1)))
@@ -206,5 +221,9 @@ public class GeneProductControllerIT {
                 GeneProductDocMocker.createDocWithId("A0A000"),
                 GeneProductDocMocker.createDocWithId("A0A001"),
                 GeneProductDocMocker.createDocWithId("A0A002"));
+    }
+
+    private List<GeneProductDocument> createBasicComplexPortalDocs() {
+        return Collections.singletonList(GeneProductDocMocker.createDocWithId("CPX-1004"));
     }
 }

--- a/solr-cores/src/main/cores/geneproduct/conf/schema.xml
+++ b/solr-cores/src/main/cores/geneproduct/conf/schema.xml
@@ -150,18 +150,6 @@
         </analyzer>
     </fieldType>
 
-    <!--<fieldType name="text_ignorecase_classic" class="solr.TextField" positionIncrementGap="100">-->
-    <!--<analyzer type="index">-->
-    <!--<tokenizer class="solr.ClassicTokenizerFactory"/>-->
-    <!--<filter class="solr.LowerCaseFilterFactory"/>-->
-    <!--</analyzer>-->
-    <!--<analyzer type="query">-->
-    <!--<tokenizer class="solr.ClassicTokenizerFactory"/>-->
-    <!--<filter class="solr.LowerCaseFilterFactory"/>-->
-    <!--</analyzer>-->
-    <!--</fieldType>-->
-
-
     <!-- field type definitions. The "name" attribute is
        just a label to be used by field definitions.  The "class"
      attribute and any other attributes determine the real

--- a/solr-cores/src/main/cores/geneproduct/conf/schema.xml
+++ b/solr-cores/src/main/cores/geneproduct/conf/schema.xml
@@ -141,14 +141,25 @@
 
     <fieldType name="text_ignorecase" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">
-            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <tokenizer class="solr.ClassicTokenizerFactory"/>
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>
         <analyzer type="query">
-            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <tokenizer class="solr.ClassicTokenizerFactory"/>
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>
     </fieldType>
+
+    <!--<fieldType name="text_ignorecase_classic" class="solr.TextField" positionIncrementGap="100">-->
+    <!--<analyzer type="index">-->
+    <!--<tokenizer class="solr.ClassicTokenizerFactory"/>-->
+    <!--<filter class="solr.LowerCaseFilterFactory"/>-->
+    <!--</analyzer>-->
+    <!--<analyzer type="query">-->
+    <!--<tokenizer class="solr.ClassicTokenizerFactory"/>-->
+    <!--<filter class="solr.LowerCaseFilterFactory"/>-->
+    <!--</analyzer>-->
+    <!--</fieldType>-->
 
 
     <!-- field type definitions. The "name" attribute is


### PR DESCRIPTION
The hyphen in ComplexPortal ids has stops the identifier being treated as a single entity within Solr - its is broken up by the StandardTokienizer.  I've used the ClassicTokenizer instead.